### PR TITLE
ContactRoles: Initialize variable $query

### DIFF
--- a/CRM/Remotetools/ContactRoles.php
+++ b/CRM/Remotetools/ContactRoles.php
@@ -71,6 +71,7 @@ class CRM_Remotetools_ContactRoles
 
             // load contact roles
             $roles_field = CRM_Remotetools_CustomData::getCustomFieldKey('remote_contact_data', 'remote_contact_roles');
+            $query = [];
             CRM_Remotetools_CustomData::resolveCustomFields($query);
             $roles = civicrm_api3('Contact', 'getvalue', [
                 'id'     => $contact_id,


### PR DESCRIPTION
`CRM_Remotetools_CustomData::resolveCustomFields()` expects an array, but `$query` is not defined. On my PHP 8.1 environment this leads to a `TypeError` here: https://github.com/systopia/de.systopia.remotetools/blob/af1b521ea29ed9d9bd8c31c53be243e7e8dd5f82/CRM/Remotetools/CustomData.php#L446