### PR TITLE
Use extension's autoloader in config and container hooks

### DIFF
--- a/remotetools.php
+++ b/remotetools.php
@@ -22,6 +22,17 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\Config\Resource\GlobResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
+function _remotetools_composer_autoload(): void {
+    if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+        $classLoader = require_once __DIR__ . '/vendor/autoload.php';
+        if ($classLoader instanceof \Composer\Autoload\ClassLoader) {
+            // Re-register class loader to append it. (It's automatically prepended.)
+            $classLoader->unregister();
+            $classLoader->register();
+        }
+    }
+}
+
 /**
  * Implements hook_civicrm_config().
  *
@@ -29,6 +40,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 function remotetools_civicrm_config(&$config)
 {
+    _remotetools_composer_autoload();
     _remotetools_civix_civicrm_config($config);
 
    // register events (with our own wrapper to avoid duplicate registrations)
@@ -67,14 +79,7 @@ function remotetools_civicrm_config(&$config)
 }
 
 function remotetools_civicrm_container(ContainerBuilder $container): void {
-    if (file_exists(__DIR__ . '/vendor/autoload.php')) {
-        $classLoader = require_once __DIR__ . '/vendor/autoload.php';
-        if ($classLoader instanceof \Composer\Autoload\ClassLoader) {
-            // Re-register class loader to append it. (It's automatically prepended.)
-            $classLoader->unregister();
-            $classLoader->register();
-        }
-    }
+    _remotetools_composer_autoload();
 
     // Allow lazy service instantiation (requires symfony/proxy-manager-bridge)
     if (class_exists(\ProxyManager\Configuration::class) && class_exists(RuntimeInstantiator::class)) {


### PR DESCRIPTION
... as there might be errors after clearing caches.