### PR TITLE
OpisValidatorFactory: Enable conversion of empty arrays to `\stdClass` object if necessary

### DIFF
--- a/Civi/RemoteTools/JsonSchema/Validation/OpisValidatorFactory.php
+++ b/Civi/RemoteTools/JsonSchema/Validation/OpisValidatorFactory.php
@@ -32,6 +32,7 @@ final class OpisValidatorFactory {
     if (!isset(self::$validator)) {
       $expressionHandler = new SymfonyExpressionHandler(new SystopiaExpressionLanguage());
       self::$validator = new SystopiaValidator([
+        'convertEmptyArrays' => TRUE,
         'calculator' => $expressionHandler,
         'evaluator' => $expressionHandler,
       ]);

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "systopia/expression-language-ext": "~0.1",
-        "systopia/opis-json-schema-ext": "~0.2",
+        "systopia/opis-json-schema-ext": "~0.3",
         "webmozart/assert": "^1"
     },
     "scripts": {


### PR DESCRIPTION
See https://github.com/systopia/opis-json-schema-ext?tab=readme-ov-file#empty-array-to-object-conversion

systopia-reference: 24256