### PR TITLE
Do not try to `explode()` return parameter when it already is an array

### DIFF
--- a/Civi/RemoteToolsRequest.php
+++ b/Civi/RemoteToolsRequest.php
@@ -346,9 +346,12 @@ class RemoteToolsRequest extends Event
      */
     public function getOriginalReturnFields()
     {
-        $return_string = \CRM_Utils_Array::value('return', $this->original_request, '');
-        if ($return_string) {
-            return explode(',', $return_string);
+        $return = $this->original_request['return'] ?? [];
+        if (is_array($return)) {
+            return $return;
+        }
+        if (is_string($return)) {
+            return explode(',', $return);
         } else {
             return [];
         }


### PR DESCRIPTION
On PHP 8, `explode()` throws a `TypeError` instead of issueing a warning, so requests will fail without a proper error message when the `return` parameter is not a string.

This PR adds a check for whether the `return` parameter already is an array. I'm not sure it will ever be a string, as in my testing even for just a single value this was an array.