### PR TITLE
JsonSchema: Add method `__clone()`

### DIFF
--- a/Civi/RemoteTools/JsonSchema/JsonSchema.php
+++ b/Civi/RemoteTools/JsonSchema/JsonSchema.php
@@ -139,6 +139,19 @@ class JsonSchema implements \ArrayAccess, \JsonSerializable {
     $this->keywords = $keywords;
   }
 
+  public function __clone() {
+    $this->keywords = array_map(function ($value) {
+      if (is_object($value)) {
+        return clone $value;
+      }
+      elseif (is_array($value)) {
+        return array_values(array_map(fn ($value) => is_object($value) ? clone $value : $value, $value));
+      }
+
+      return $value;
+    }, $this->keywords);
+  }
+
   /**
    * @param string $keyword
    * @param TValue $value

--- a/tests/phpunit/Civi/RemoteTools/JsonSchema/JsonSchemaTest.php
+++ b/tests/phpunit/Civi/RemoteTools/JsonSchema/JsonSchemaTest.php
@@ -101,6 +101,20 @@ final class JsonSchemaTest extends TestCase {
     JsonSchema::fromArray(['foo' => new \stdClass()]);
   }
 
+  public function testClone(): void {
+    $schema = new JsonSchema([
+      'foo' => new JsonSchema(['bar' => 'baz']),
+      'fuu' => [1, 2, new JsonSchemaString(['keyword' => 'value']), TRUE],
+      'f00' => NULL,
+    ]);
+
+    $clone = clone $schema;
+
+    static::assertEquals($schema, $clone);
+    static::assertNotSame($schema, $clone);
+    static::assertNotSame($schema->getKeywords(), $clone->getKeywords());
+  }
+
   public function testToArray(): void {
     $schema = new JsonSchema([
       'foo' => new JsonSchema(['bar' => 'baz']),


### PR DESCRIPTION
The new method allows to clone `JsonSchema` objects.

systopia-reference: 23348