### PR TITLE
Add support for tagged data (`$tag`) in JSON schema

### DIFF
--- a/Civi/RemoteTools/JsonSchema/Validation/ValidationResult.php
+++ b/Civi/RemoteTools/JsonSchema/Validation/ValidationResult.php
@@ -21,6 +21,7 @@ namespace Civi\RemoteTools\JsonSchema\Validation;
 
 use Opis\JsonSchema\Errors\ValidationError;
 use Systopia\JsonSchema\Errors\ErrorCollector;
+use Systopia\JsonSchema\Tags\TaggedDataContainerInterface;
 use Systopia\JsonSchema\Translation\ErrorTranslator;
 use Systopia\JsonSchema\Translation\NullTranslator;
 use Systopia\JsonSchema\Translation\TranslatorInterface;
@@ -32,6 +33,8 @@ final class ValidationResult {
    */
   private array $data;
 
+  private TaggedDataContainerInterface $taggedData;
+
   private ErrorCollector $errorCollector;
 
   private ErrorTranslator $errorTranslator;
@@ -40,8 +43,14 @@ final class ValidationResult {
    * @param array<string, mixed> $data
    * @param \Systopia\JsonSchema\Errors\ErrorCollector $errorCollector
    */
-  public function __construct(array $data, ErrorCollector $errorCollector, ?TranslatorInterface $translator = NULL) {
+  public function __construct(
+    array $data,
+    TaggedDataContainerInterface $taggedData,
+    ErrorCollector $errorCollector,
+    ?TranslatorInterface $translator = NULL
+  ) {
     $this->data = $data;
+    $this->taggedData = $taggedData;
     $this->errorCollector = $errorCollector;
     $this->errorTranslator = new ErrorTranslator($translator ?? new NullTranslator());
   }
@@ -51,6 +60,10 @@ final class ValidationResult {
    */
   public function getData(): array {
     return $this->data;
+  }
+
+  public function getTaggedData(): TaggedDataContainerInterface {
+    return $this->taggedData;
   }
 
   /**

--- a/Civi/RemoteTools/JsonSchema/Validation/Validator.php
+++ b/Civi/RemoteTools/JsonSchema/Validation/Validator.php
@@ -23,6 +23,7 @@ use Civi\RemoteTools\JsonSchema\JsonSchema;
 use Civi\RemoteTools\Util\JsonConverter;
 use Opis\JsonSchema\Validator as OpisValidator;
 use Systopia\JsonSchema\Errors\ErrorCollector;
+use Systopia\JsonSchema\Tags\TaggedDataContainer;
 use Systopia\JsonSchema\Translation\TranslatorInterface;
 
 final class Validator implements ValidatorInterface {
@@ -43,16 +44,25 @@ final class Validator implements ValidatorInterface {
   public function validate(JsonSchema $jsonSchema, array $data, int $maxErrors = 1): ValidationResult {
     $validationData = JsonConverter::toStdClass($data);
     $errorCollector = new ErrorCollector();
+    $taggedDataContainer = new TaggedDataContainer();
     $prevMaxErrors = $this->validator->getMaxErrors();
     try {
       $this->validator->setMaxErrors($maxErrors);
-      $this->validator->validate($validationData, $jsonSchema->toStdClass(), ['errorCollector' => $errorCollector]);
+      $this->validator->validate($validationData, $jsonSchema->toStdClass(), [
+        'errorCollector' => $errorCollector,
+        'taggedDataContainer' => $taggedDataContainer,
+      ]);
     }
     finally {
       $this->validator->setMaxErrors($prevMaxErrors);
     }
 
-    return new ValidationResult(JsonConverter::toArray($validationData), $errorCollector, $this->translator);
+    return new ValidationResult(
+      JsonConverter::toArray($validationData),
+      $taggedDataContainer,
+      $errorCollector,
+      $this->translator
+    );
   }
 
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "systopia/expression-language-ext": "~0.1",
-        "systopia/opis-json-schema-ext": "~0.3",
+        "systopia/opis-json-schema-ext": "~0.4",
         "webmozart/assert": "^1"
     },
     "scripts": {


### PR DESCRIPTION
This allows to use the `$tag` keyword from https://github.com/systopia/opis-json-schema-ext in a JSON schema to extract data.