### PR TITLE
ContactRoles: Don't fail if `remote_contact_data.remote_contact_roles` is NULL

### DIFF
--- a/CRM/Remotetools/ContactRoles.php
+++ b/CRM/Remotetools/ContactRoles.php
@@ -77,8 +77,8 @@ class CRM_Remotetools_ContactRoles
               ->single();
 
             self::$contact_roles_cache[$contact_id] = array_combine(
-                $roles['remote_contact_data.remote_contact_roles:name'],
-                $roles['remote_contact_data.remote_contact_roles:label']
+                $roles['remote_contact_data.remote_contact_roles:name'] ?? [],
+                $roles['remote_contact_data.remote_contact_roles:label'] ?? []
             );
         }
 


### PR DESCRIPTION
Because the custom field `remote_contact_data.remote_contact_roles` is not marked as required, it can not only be an empty array, but also `NULL`.

systopia-reference: 24946