### PR TITLE
Prevent TypeError when contact has no CiviRemote roles

### DIFF
--- a/CRM/Remotetools/ContactRoles.php
+++ b/CRM/Remotetools/ContactRoles.php
@@ -75,6 +75,8 @@ class CRM_Remotetools_ContactRoles
               ->addWhere('id', '=', $contact_id)
               ->execute()
               ->single();
+            $roles['remote_contact_data.remote_contact_roles:name'] ??= [];
+            $roles['remote_contact_data.remote_contact_roles:label'] ??= [];
 
             self::$contact_roles_cache[$contact_id] = array_combine(
                 $roles['remote_contact_data.remote_contact_roles:name'],


### PR DESCRIPTION
Fixes `TypeError: array_combine(): Argument #1 ($keys) must be of type array, null given in array_combine() (line 81 of /path/to/de.systopia.remotetools/CRM/Remotetools/ContactRoles.php).` when a contact has no roles (i.e. the field has never been saved and its value is thus `NULL`).