### PR TITLE
Extract interface of `ValidationResult`

### DIFF
--- a/Civi/RemoteTools/JsonSchema/Validation/ValidationResult.php
+++ b/Civi/RemoteTools/JsonSchema/Validation/ValidationResult.php
@@ -26,7 +26,7 @@ use Systopia\JsonSchema\Translation\ErrorTranslator;
 use Systopia\JsonSchema\Translation\NullTranslator;
 use Systopia\JsonSchema\Translation\TranslatorInterface;
 
-final class ValidationResult {
+final class ValidationResult implements ValidationResultInterface {
 
   /**
    * @var array<string, mixed>
@@ -67,14 +67,14 @@ final class ValidationResult {
   }
 
   /**
-   * @return array<string, non-empty-array<string>>
+   * @return array<string, non-empty-list<string>>
    */
   public function getErrorMessages(): array {
     return $this->mapErrorsToMessages($this->errorCollector->getErrors());
   }
 
   /**
-   * @return array<string, non-empty-array<string>>
+   * @return array<string, non-empty-list<string>>
    */
   public function getLeafErrorMessages(): array {
     return $this->mapErrorsToMessages($this->errorCollector->getLeafErrors());
@@ -89,9 +89,9 @@ final class ValidationResult {
   }
 
   /**
-   * @param array<string, non-empty-array<ValidationError>> $errors
+   * @param array<string, non-empty-list<ValidationError>> $errors
    *
-   * @return array<string, non-empty-array<string>>
+   * @return array<string, non-empty-list<string>>
    */
   private function mapErrorsToMessages(array $errors): array {
     return array_map(

--- a/Civi/RemoteTools/JsonSchema/Validation/ValidationResultInterface.php
+++ b/Civi/RemoteTools/JsonSchema/Validation/ValidationResultInterface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2022 SYSTOPIA GmbH
+ * Copyright (C) 2024 SYSTOPIA GmbH
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published by
@@ -19,13 +19,29 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\JsonSchema\Validation;
 
-use Civi\RemoteTools\JsonSchema\JsonSchema;
+use Systopia\JsonSchema\Tags\TaggedDataContainerInterface;
 
-interface ValidatorInterface {
+interface ValidationResultInterface {
 
   /**
-   * @phpstan-param array<string, mixed> $data JSON serializable.
+   * @return array<string, mixed>
    */
-  public function validate(JsonSchema $jsonSchema, array $data, int $maxErrors = 1): ValidationResultInterface;
+  public function getData(): array;
+
+  public function getTaggedData(): TaggedDataContainerInterface;
+
+  /**
+   * @return array<string, non-empty-list<string>>
+   */
+  public function getErrorMessages(): array;
+
+  /**
+   * @return array<string, non-empty-list<string>>
+   */
+  public function getLeafErrorMessages(): array;
+
+  public function hasErrors(): bool;
+
+  public function isValid(): bool;
 
 }

--- a/Civi/RemoteTools/JsonSchema/Validation/Validator.php
+++ b/Civi/RemoteTools/JsonSchema/Validation/Validator.php
@@ -41,7 +41,7 @@ final class Validator implements ValidatorInterface {
    * @inheritDoc
    * @throws \JsonException
    */
-  public function validate(JsonSchema $jsonSchema, array $data, int $maxErrors = 1): ValidationResult {
+  public function validate(JsonSchema $jsonSchema, array $data, int $maxErrors = 1): ValidationResultInterface {
     $validationData = JsonConverter::toStdClass($data);
     $errorCollector = new ErrorCollector();
     $taggedDataContainer = new TaggedDataContainer();


### PR DESCRIPTION
This allows to use mocks in tests. The constructor of `ValidationResult` is only useful when a real validation was performed.