### PR TITLE
Add support for collapsible form element container

### DIFF
--- a/Civi/RemoteTools/Form/FormSpec/FormElementContainer.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormElementContainer.php
@@ -26,8 +26,20 @@ namespace Civi\RemoteTools\Form\FormSpec;
  */
 class FormElementContainer extends AbstractFormElementContainer implements FormElementInterface {
 
+  private bool $collapsible = FALSE;
+
   public function getType(): string {
     return 'container';
+  }
+
+  public function isCollapsible(): bool {
+    return $this->collapsible;
+  }
+
+  public function setCollapsible(bool $collapsible): self {
+    $this->collapsible = $collapsible;
+
+    return $this;
   }
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/GroupFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/GroupFactory.php
@@ -24,6 +24,7 @@ use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
 use Civi\RemoteTools\JsonForms\FormSpec\ElementUiSchemaFactoryInterface;
 use Civi\RemoteTools\JsonForms\FormSpec\Factory\AbstractConcreteElementUiSchemaFactory;
 use Civi\RemoteTools\JsonForms\JsonFormsElement;
+use Civi\RemoteTools\JsonForms\Layout\JsonFormsCloseableGroup;
 use Civi\RemoteTools\JsonForms\Layout\JsonFormsGroup;
 use Webmozart\Assert\Assert;
 
@@ -36,6 +37,10 @@ final class GroupFactory extends AbstractConcreteElementUiSchemaFactory {
     Assert::isInstanceOf($element, FormElementContainer::class);
     /** @var \Civi\RemoteTools\Form\FormSpec\FormElementContainer $element */
     $elements = array_map([$factory, 'createSchema'], $element->getElements());
+
+    if ($element->isCollapsible()) {
+      return new JsonFormsCloseableGroup($element->getTitle(), $elements);
+    }
 
     return new JsonFormsGroup($element->getTitle(), $elements);
   }


### PR DESCRIPTION
Allow to mark a `FormElementContainer` as closeable. In a Drupal form it results in a `details` element.

systopia-reference: 25909