### PR TITLE
Mark `FilePersisterInterface` as `apiService`

### DIFF
--- a/Civi/RemoteTools/Helper/FilePersisterInterface.php
+++ b/Civi/RemoteTools/Helper/FilePersisterInterface.php
@@ -19,9 +19,14 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Helper;
 
+/**
+ * @apiService
+ */
 interface FilePersisterInterface {
 
   /**
+   * Requires an open database transaction.
+   *
    * @returns int ID of File entity.
    *
    * @throws \CRM_Core_Exception
@@ -29,6 +34,8 @@ interface FilePersisterInterface {
   public function persistFile(string $filename, string $content, ?string $description, ?int $contactId): int;
 
   /**
+   * Requires an open database transaction.
+   *
    * @phpstan-param array{filename: string, content: string} $file
    *   The property 'content' contains the Base64 encoded file.
    *

--- a/README.md
+++ b/README.md
@@ -80,6 +80,13 @@ with `@api` then this applies to all methods within it. If you'd like to use
 code that is not labeled as API, yet, please open an issue, so we can consider
 to add it to the API.
 
+Additionally, interfaces marked with `@apiService`, have a corresponding service
+in the DI container that can be safely used by third parties. Though in contrast
+to `@api` those interfaces should not be implemented.
+
+Services are private by default. If you need a service of this extension as
+public service, just make a public alias.
+
 #### Forms
 
 Forms for creation and update are specified in a


### PR DESCRIPTION
Allow the service `\Civi\RemoteTools\Helper\FilePersisterInterface` to be used by third parties, e.g. https://github.com/systopia/de.systopia.remoteevent/pull/96.

systopia-reference: 26007