### PR TITLE
Remote entity profile: Allow to restrict access with join

### DIFF
--- a/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandler.php
+++ b/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandler.php
@@ -31,6 +31,7 @@ use Civi\RemoteTools\Api4\Action\RemoteSubmitUpdateFormAction;
 use Civi\RemoteTools\Api4\Action\RemoteValidateCreateFormAction;
 use Civi\RemoteTools\Api4\Action\RemoteValidateUpdateFormAction;
 use Civi\RemoteTools\Api4\Api4Interface;
+use Civi\RemoteTools\Api4\Query\Join;
 use Civi\RemoteTools\Api4\Query\QueryApplier;
 use Civi\RemoteTools\EntityProfile\EntityProfileOptionSuffixDecorator;
 use Civi\RemoteTools\EntityProfile\EntityProfilePermissionDecorator;
@@ -363,6 +364,11 @@ abstract class AbstractProfileEntityActionsHandler implements RemoteEntityAction
    * @throws \CRM_Core_Exception
    */
   protected function getEntityById(int $id, string $actionName, ?int $contactId): ?array {
+    $join = array_map(
+      fn (Join $join) => $join->toArray(),
+      $this->profile->getJoins($actionName, $contactId)
+    );
+
     $where = [['id', '=', $id]];
     $filter = $this->profile->getFilter($actionName, $contactId);
     if (NULL !== $filter) {
@@ -371,6 +377,7 @@ abstract class AbstractProfileEntityActionsHandler implements RemoteEntityAction
 
     return $this->api4->execute($this->profile->getEntityName(), 'get', [
       'select' => $this->profile->getSelectFieldNames(['*'], $actionName, [], $contactId),
+      'join' => $join,
       'where' => $where,
       'checkPermissions' => $this->profile->isCheckApiPermissions($contactId),
     ])->first();

--- a/Civi/RemoteTools/Api4/Query/ConditionInterface.php
+++ b/Civi/RemoteTools/Api4/Query/ConditionInterface.php
@@ -23,6 +23,8 @@ namespace Civi\RemoteTools\Api4\Query;
  * @phpstan-import-type comparisonT from Comparison
  * @phpstan-import-type compositeConditionT from CompositeCondition
  *
+ * @phpstan-type conditionT comparisonT|compositeConditionT
+ *
  * @api
  */
 interface ConditionInterface {
@@ -30,8 +32,7 @@ interface ConditionInterface {
   public function getOperator(): string;
 
   /**
-   * @return array
-   * @phpstan-return comparisonT|compositeConditionT
+   * @phpstan-return conditionT
    */
   public function toArray(): array;
 

--- a/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfile.php
+++ b/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfile.php
@@ -61,6 +61,13 @@ abstract class AbstractRemoteEntityProfile implements RemoteEntityProfileInterfa
   /**
    * @inheritDoc
    */
+  public function getJoins(string $actionName, ?int $contactId): array {
+    return [];
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function isImplicitJoinAllowed(string $fieldName, string $joinFieldName, ?int $contactId): bool {
     return FALSE;
   }

--- a/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfileDecorator.php
+++ b/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfileDecorator.php
@@ -101,6 +101,13 @@ abstract class AbstractRemoteEntityProfileDecorator implements RemoteEntityProfi
   /**
    * @inheritDoc
    */
+  public function getJoins(string $actionName, ?int $contactId): array {
+    return $this->profile->getJoins($actionName, $contactId);
+  }
+
+  /**
+   * @inheritDoc
+   */
   public function convertRemoteFieldComparison(Comparison $comparison, ?int $contactId): ?ConditionInterface {
     return $this->profile->convertRemoteFieldComparison($comparison, $contactId);
   }

--- a/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityDeleter.php
+++ b/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityDeleter.php
@@ -22,6 +22,7 @@ namespace Civi\RemoteTools\EntityProfile\Helper;
 use Civi\RemoteTools\Api4\Action\RemoteDeleteAction;
 use Civi\RemoteTools\Api4\Api4Interface;
 use Civi\RemoteTools\Api4\Query\Comparison;
+use Civi\RemoteTools\Api4\Query\Join;
 use Civi\RemoteTools\EntityProfile\RemoteEntityProfileInterface;
 use Civi\RemoteTools\Helper\WhereFactoryInterface;
 use Webmozart\Assert\Assert;
@@ -55,10 +56,15 @@ final class ProfileEntityDeleter implements ProfileEntityDeleterInterface {
     ])->indexBy('name')->getArrayCopy();
     $remoteFields = $profile->getRemoteFields($entityFields, $action->getResolvedContactId());
 
+    $join = array_map(
+      fn (Join $join) => $join->toArray(),
+      $profile->getJoins('delete', $action->getResolvedContactId())
+    );
     $where = $this->createWhereForDelete($profile, $action, $entityFields, $remoteFields);
 
     $getResult = $this->api4->execute($profile->getEntityName(), 'get', [
       'select' => $profile->getSelectFieldNames(['*'], 'delete', [], $action->getResolvedContactId()),
+      'join' => $join,
       'where' => $where,
       'checkPermissions' => $profile->isCheckApiPermissions($action->getResolvedContactId()),
     ]);

--- a/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityLoader.php
+++ b/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityLoader.php
@@ -23,6 +23,7 @@ use Civi\Api4\Generic\Result;
 use Civi\RemoteTools\Api4\Action\RemoteGetAction;
 use Civi\RemoteTools\Api4\Api4Interface;
 use Civi\RemoteTools\Api4\Query\Comparison;
+use Civi\RemoteTools\Api4\Query\Join;
 use Civi\RemoteTools\Api4\Query\QueryApplier;
 use Civi\RemoteTools\EntityProfile\RemoteEntityProfileInterface;
 use Civi\RemoteTools\Helper\SelectFactoryInterface;
@@ -60,6 +61,10 @@ final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
     $remoteFields = $profile->getRemoteFields($entityFields, $action->getResolvedContactId());
 
     $selects = $this->createSelectsForGet($profile, $action, $entityFields, $remoteFields);
+    $join = array_map(
+      fn (Join $join) => $join->toArray(),
+      $profile->getJoins('get', $action->getResolvedContactId())
+    );
     $where = $this->createWhereForGet($profile, $action, $entityFields, $remoteFields);
 
     $entityOrderBy = [];
@@ -74,6 +79,7 @@ final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
 
     $result = $this->api4->execute($profile->getEntityName(), 'get', [
       'select' => $selects['entity'],
+      'join' => $join,
       'where' => $where,
       'orderBy' => $entityOrderBy,
       'limit' => $action->getLimit(),

--- a/Civi/RemoteTools/EntityProfile/RemoteEntityProfileInterface.php
+++ b/Civi/RemoteTools/EntityProfile/RemoteEntityProfileInterface.php
@@ -164,6 +164,18 @@ interface RemoteEntityProfileInterface {
   public function getFilter(string $actionName, ?int $contactId): ?ConditionInterface;
 
   /**
+   * Might be used to restrict access using related entities.
+   *
+   * @phpstan-param 'delete'|'get'|'update' $actionName
+   *
+   * @phpstan-return list<\Civi\RemoteTools\Api4\Query\Join>
+   *   Joins added to the query.
+   *
+   * @api
+   */
+  public function getJoins(string $actionName, ?int $contactId): array;
+
+  /**
    * @phpstan-param array<string, mixed> $entityValues
    * @phpstan-param array<string> $select
    *   Selected field names. Maybe empty on create or update.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -42,7 +42,6 @@ parameters:
 
 		- '#^Method Civi\\RemoteTools\\Api4\\Action\\[^\s]+Action::getHandlerResult\(\) has Civi\\RemoteTools\\Exception\\ActionHandlerNotFoundException in PHPDoc @throws tag but it.s not thrown.$#'
 		- '#^Method Civi\\RemoteTools\\Api4\\Api4::createAction\(\) should return Civi\\Api4\\Generic\\AbstractAction but returns array|Civi\Api4\Generic\AbstractAction.$#'
-		- '#^Method Civi\\RemoteTools\\Api4\\Query\\[^\\]+::toArray\(\) return type has no value type specified in iterable type array.$#'
 
 		- '#^Method Civi\\RemoteTools\\Fixture\\[^\s]+Fixture::[^\s]+ should return array\{id: int\} but returns array.$#'
 		-

--- a/tests/phpunit/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityLoaderTest.php
+++ b/tests/phpunit/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityLoaderTest.php
@@ -7,6 +7,7 @@ use Civi\Api4\Generic\Result;
 use Civi\RemoteTools\Api4\Action\RemoteGetAction;
 use Civi\RemoteTools\Api4\Api4Interface;
 use Civi\RemoteTools\Api4\Query\Comparison;
+use Civi\RemoteTools\Api4\Query\Join;
 use Civi\RemoteTools\EntityProfile\RemoteEntityProfileInterface;
 use Civi\RemoteTools\Helper\SelectFactoryInterface;
 use Civi\RemoteTools\Helper\WhereFactoryInterface;
@@ -100,6 +101,12 @@ final class ProfileEntityLoaderTest extends TestCase {
       ->with($entitySelect, 'get', $remoteSelect, $resolvedContactId)
       ->willReturn($profileEntitySelect);
 
+    $profileJoin = Join::newWithBridge('JoinedEntity', 'j', 'INNER', 'bridge');
+    $profileMock->method('getJoins')
+      ->with('get', $resolvedContactId)
+      ->willReturn([$profileJoin]);
+    $entityJoin = [['JoinedEntity AS j', 'INNER', 'bridge']];
+
     $profileFilter = Comparison::new('extra', '!=', 'abc');
     $profileMock->method('getFilter')
       ->with('get', $resolvedContactId)
@@ -135,6 +142,7 @@ final class ProfileEntityLoaderTest extends TestCase {
           'get',
           [
             'select' => $profileEntitySelect,
+            'join' => $entityJoin,
             'where' => $entityWhereWithFilter,
             'orderBy' => ['foo' => 'DESC'],
             'limit' => 10,


### PR DESCRIPTION
This allows to restrict entity access using joins to related entities. Previously entities could only filtered by fields of the entity itself.

systopia-reference: 26544