### PR TITLE
Add support for vertical tabs in remote forms

### DIFF
--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormElementContainer.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormElementContainer.php
@@ -22,6 +22,8 @@ namespace Civi\RemoteTools\Form\FormSpec;
 use Civi\RemoteTools\Form\FormSpec\Button\SubmitButton;
 
 /**
+ * @template T of FormElementInterface
+ *
  * @api
  */
 abstract class AbstractFormElementContainer {
@@ -29,12 +31,12 @@ abstract class AbstractFormElementContainer {
   private string $title;
 
   /**
-   * @phpstan-var array<FormElementInterface>
+   * @phpstan-var array<T>
    */
   private array $elements = [];
 
   /**
-   * @phpstan-param array<FormElementInterface> $elements
+   * @phpstan-param array<T> $elements
    */
   public function __construct(string $title, array $elements = []) {
     $this->title = $title;
@@ -55,6 +57,8 @@ abstract class AbstractFormElementContainer {
   }
 
   /**
+   * @phpstan-param T $element
+   *
    * @return $this
    */
   public function addElement(FormElementInterface $element): self {
@@ -64,7 +68,7 @@ abstract class AbstractFormElementContainer {
   }
 
   /**
-   * @phpstan-return array<FormElementInterface>
+   * @phpstan-return array<T>
    */
   public function getElements(): array {
     return $this->elements;
@@ -75,6 +79,8 @@ abstract class AbstractFormElementContainer {
   }
 
   /**
+   * @phpstan-param T $element
+   *
    * @return $this
    */
   public function insertElement(FormElementInterface $element, int $index): self {
@@ -84,7 +90,7 @@ abstract class AbstractFormElementContainer {
   }
 
   /**
-   * @phpstan-param array<FormElementInterface> $elements
+   * @phpstan-param array<T> $elements
    */
   public function setElements(array $elements): self {
     $this->elements = $elements;
@@ -102,7 +108,7 @@ abstract class AbstractFormElementContainer {
       if ($element instanceof AbstractFormField) {
         $fields[$element->getName()] = $element;
       }
-      elseif ($element instanceof FormElementContainer) {
+      elseif ($element instanceof AbstractFormElementContainer) {
         $containerFields = $element->getFields();
         $nonUniqueFields = array_keys(array_intersect_key($fields, $containerFields));
         if ([] !== $nonUniqueFields) {

--- a/Civi/RemoteTools/Form/FormSpec/FormSpec.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormSpec.php
@@ -20,6 +20,8 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\Form\FormSpec;
 
 /**
+ * @extends AbstractFormElementContainer<FormElementInterface>
+ *
  * @api
  */
 final class FormSpec extends AbstractFormElementContainer {

--- a/Civi/RemoteTools/Form/FormSpec/FormTab.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormTab.php
@@ -22,24 +22,27 @@ namespace Civi\RemoteTools\Form\FormSpec;
 /**
  * @codeCoverageIgnore
  *
- * @extends AbstractFormElementContainer<FormElementInterface>
- *
  * @api
  */
-class FormElementContainer extends AbstractFormElementContainer implements FormElementInterface {
+class FormTab extends AbstractFormElementContainer implements FormElementInterface {
 
-  private bool $collapsible = FALSE;
+  public ?string $description;
+
+  public function __construct(string $title, array $elements = [], ?string $description = NULL) {
+    parent::__construct($title, $elements);
+    $this->description = $description;
+  }
 
   public function getType(): string {
-    return 'container';
+    return 'tab';
   }
 
-  public function isCollapsible(): bool {
-    return $this->collapsible;
+  public function getDescription(): ?string {
+    return $this->description;
   }
 
-  public function setCollapsible(bool $collapsible): self {
-    $this->collapsible = $collapsible;
+  public function setDescription(?string $description): self {
+    $this->description = $description;
 
     return $this;
   }

--- a/Civi/RemoteTools/Form/FormSpec/VerticalTabsContainer.php
+++ b/Civi/RemoteTools/Form/FormSpec/VerticalTabsContainer.php
@@ -22,26 +22,18 @@ namespace Civi\RemoteTools\Form\FormSpec;
 /**
  * @codeCoverageIgnore
  *
- * @extends AbstractFormElementContainer<FormElementInterface>
+ * @extends AbstractFormElementContainer<FormTab>
  *
  * @api
  */
-class FormElementContainer extends AbstractFormElementContainer implements FormElementInterface {
+class VerticalTabsContainer extends AbstractFormElementContainer implements FormElementInterface {
 
-  private bool $collapsible = FALSE;
+  public function __construct(array $elements = []) {
+    parent::__construct('', $elements);
+  }
 
   public function getType(): string {
-    return 'container';
-  }
-
-  public function isCollapsible(): bool {
-    return $this->collapsible;
-  }
-
-  public function setCollapsible(bool $collapsible): self {
-    $this->collapsible = $collapsible;
-
-    return $this;
+    return 'vertical_tabs';
   }
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategorizationFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategorizationFactory.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\JsonForms\FormSpec\Factory\Layout;
+
+use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
+use Civi\RemoteTools\Form\FormSpec\VerticalTabsContainer;
+use Civi\RemoteTools\JsonForms\FormSpec\ElementUiSchemaFactoryInterface;
+use Civi\RemoteTools\JsonForms\FormSpec\Factory\AbstractConcreteElementUiSchemaFactory;
+use Civi\RemoteTools\JsonForms\JsonFormsElement;
+use Civi\RemoteTools\JsonForms\Layout\JsonFormsCategorization;
+use Webmozart\Assert\Assert;
+
+final class CategorizationFactory extends AbstractConcreteElementUiSchemaFactory {
+
+  public function createSchema(
+    FormElementInterface $element,
+    ElementUiSchemaFactoryInterface $factory
+  ): JsonFormsElement {
+    Assert::isInstanceOf($element, VerticalTabsContainer::class);
+    /** @var \Civi\RemoteTools\Form\FormSpec\VerticalTabsContainer $element */
+    $elements = array_map([$factory, 'createSchema'], $element->getElements());
+
+    return new JsonFormsCategorization($elements);
+  }
+
+  public function supportsElement(FormElementInterface $element): bool {
+    return $element instanceof VerticalTabsContainer;
+  }
+
+}

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategoryFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategoryFactory.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\JsonForms\FormSpec\Factory\Layout;
+
+use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
+use Civi\RemoteTools\Form\FormSpec\FormTab;
+use Civi\RemoteTools\JsonForms\FormSpec\ElementUiSchemaFactoryInterface;
+use Civi\RemoteTools\JsonForms\FormSpec\Factory\AbstractConcreteElementUiSchemaFactory;
+use Civi\RemoteTools\JsonForms\JsonFormsElement;
+use Civi\RemoteTools\JsonForms\Layout\JsonFormsCategory;
+use Webmozart\Assert\Assert;
+
+final class CategoryFactory extends AbstractConcreteElementUiSchemaFactory {
+
+  public function createSchema(
+    FormElementInterface $element,
+    ElementUiSchemaFactoryInterface $factory
+  ): JsonFormsElement {
+    Assert::isInstanceOf($element, FormTab::class);
+    /** @var \Civi\RemoteTools\Form\FormSpec\FormTab $element */
+    $elements = array_map([$factory, 'createSchema'], $element->getElements());
+
+    return new JsonFormsCategory($element->getTitle(), $elements, $element->getDescription());
+  }
+
+  public function supportsElement(FormElementInterface $element): bool {
+    return $element instanceof FormTab;
+  }
+
+}


### PR DESCRIPTION
With this change a `\Civi\RemoteTools\Form\FormSpec\VerticalTabsContainer` with `\Civi\RemoteTools\Form\FormSpec\FormTab` as elements can be used to add vertical tabs to a remote form. A `\Civi\RemoteTools\Form\FormSpec\FormTab` is a container for any form element.

systopia-reference: 26546