### PR TITLE
Fix remote getFields action

### DIFF
--- a/Civi/RemoteTools/Api4/Action/RemoteGetFieldsAction.php
+++ b/Civi/RemoteTools/Api4/Action/RemoteGetFieldsAction.php
@@ -19,7 +19,6 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Api4\Action;
 
-use Civi\Api4\Generic\Result;
 use Civi\RemoteTools\Api4\Action\Traits\ProfileParameterOptionalTrait;
 use Civi\RemoteTools\Exception\ActionHandlerNotFoundException;
 
@@ -39,21 +38,17 @@ class RemoteGetFieldsAction extends AbstractRemoteGetFieldsAction implements Pro
   // Called by API explorer and SearchKit, so parameters need to be optional.
   use ProfileParameterOptionalTrait;
 
-  public function _run(Result $result): void {
+  protected function getRecords(): array {
     try {
-      $this->doRun($result);
+      return parent::getRecords();
     }
-    // @phpstan-ignore-next-line
     catch (ActionHandlerNotFoundException $e) {
       if (NULL !== $this->profile) {
         throw $e;
       }
 
-      if ('getFields' === $this->action) {
-        $result->exchangeArray($this->fields());
-      }
-      elseif ($this->select !== ['row_count']) {
-        $result[] = [
+      return [
+        [
           'default_value' => NULL,
           'type' => 'Field',
           'entity' => $this->getEntityName(),
@@ -65,12 +60,8 @@ class RemoteGetFieldsAction extends AbstractRemoteGetFieldsAction implements Pro
           'data_type' => 'Integer',
           'options' => FALSE,
           'label' => 'ID',
-        ];
-      }
-
-      if (in_array('row_count', $this->select, TRUE)) {
-        $result->setCountMatched($result->count());
-      }
+        ],
+      ];
     }
   }
 

--- a/Civi/RemoteTools/Api4/Util/WhereUtil.php
+++ b/Civi/RemoteTools/Api4/Util/WhereUtil.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Api4\Util;
+
+/**
+ * @phpstan-type whereT list<array{string, string|list<mixed>, 2?: mixed}>
+ *   "list<mixed>" is actually a condition of a composite condition so we have
+ *   a recursion that cannot be expressed in a phpstan type. The third entry is
+ *   not given for composite conditions.
+ *
+ * @codeCoverageIgnore
+ */
+final class WhereUtil {
+
+  /**
+   * @phpstan-param whereT $where
+   *
+   * @phpstan-return array<string>
+   *   Field names used in where.
+   */
+  public static function getFields(array $where): array {
+    $fields = [];
+
+    foreach ($where as $clause) {
+      if (is_array($clause[1])) {
+        // Composite condition.
+        // @phpstan-ignore argument.type
+        $fields = array_merge($fields, self::getFields($clause[1]));
+      }
+      else {
+        $fields[] = $clause[0];
+      }
+    }
+
+    return array_unique($fields);
+  }
+
+}


### PR DESCRIPTION
* `RemoteActionInterface` was missing as implemented in `AbstractRemoteGetFieldsAction` so remote contact ID weren't resolved.
* `AbstractRemoteGetFieldsAction` now extends `BasicGetFieldsAction` so the phpdoc type hint of `AbstractEntity::getFields()` is matched.

systopia-reference: 27543