### PR TITLE
`Api4`: Allow to use extra parameters in all methods

### DIFF
--- a/Civi/RemoteTools/Api4/Api4.php
+++ b/Civi/RemoteTools/Api4/Api4.php
@@ -40,12 +40,11 @@ final class Api4 implements Api4Interface {
     self::$instance = $this;
   }
 
-  public function countEntities(string $entityName, ConditionInterface $where, array $options = []): int {
+  public function countEntities(string $entityName, ConditionInterface $where, array $extraParams = []): int {
     return $this->execute($entityName, 'get', [
-      'checkPermissions' => $options['checkPermissions'] ?? FALSE,
       'select' => ['row_count'],
       'where' => [$where->toArray()],
-    ])->countMatched();
+    ] + $extraParams)->countMatched();
   }
 
   /**
@@ -68,11 +67,10 @@ final class Api4 implements Api4Interface {
   /**
    * @inheritDoc
    */
-  public function createEntity(string $entityName, array $values, array $options = []): Result {
+  public function createEntity(string $entityName, array $values, array $extraParams = []): Result {
     return $this->execute($entityName, 'create', [
-      'checkPermissions' => $options['checkPermissions'] ?? FALSE,
       'values' => $values,
-    ]);
+    ] + $extraParams);
   }
 
   /**
@@ -86,18 +84,19 @@ final class Api4 implements Api4Interface {
   /**
    * @inheritDoc
    */
-  public function deleteEntities(string $entityName, ConditionInterface $condition, array $options = []): Result {
+  public function deleteEntities(string $entityName, ConditionInterface $condition, array $extraParams = []): Result {
     return $this->execute($entityName, 'delete', [
-      'checkPermissions' => $options['checkPermissions'] ?? FALSE,
       'where' => [$condition->toArray()],
-    ]);
+    ] + $extraParams);
   }
 
-  public function deleteEntity(string $entityName, int $id, array $options = []): Result {
+  /**
+   * @inheritDoc
+   */
+  public function deleteEntity(string $entityName, int $id, array $extraParams = []): Result {
     return $this->execute($entityName, 'delete', [
-      'checkPermissions' => $options['checkPermissions'] ?? FALSE,
       'where' => [['id', '=', $id]],
-    ]);
+    ] + $extraParams);
   }
 
   /**
@@ -133,19 +132,23 @@ final class Api4 implements Api4Interface {
     ] + $extraParams);
   }
 
-  public function getEntity(string $entityName, int $id, array $options = []): ?array {
+  /**
+   * @inheritDoc
+   */
+  public function getEntity(string $entityName, int $id, array $extraParams = []): ?array {
     return $this->execute($entityName, 'get', [
-      'checkPermissions' => $options['checkPermissions'] ?? FALSE,
       'where' => [['id', '=', $id]],
-    ])->first();
+    ] + $extraParams)->first();
   }
 
-  public function updateEntity(string $entityName, int $id, array $values, array $options = []): Result {
+  /**
+   * @inheritDoc
+   */
+  public function updateEntity(string $entityName, int $id, array $values, array $extraParams = []): Result {
     return $this->execute($entityName, 'update', [
-      'checkPermissions' => $options['checkPermissions'] ?? FALSE,
       'where' => [['id', '=', $id]],
       'values' => $values,
-    ]);
+    ] + $extraParams);
   }
 
 }

--- a/Civi/RemoteTools/Api4/Api4Interface.php
+++ b/Civi/RemoteTools/Api4/Api4Interface.php
@@ -33,12 +33,11 @@ use Civi\RemoteTools\Api4\Query\ConditionInterface;
 interface Api4Interface {
 
   /**
-   * @phpstan-param array{checkPermissions?: bool} $options
-   *   checkPermissions defaults to FALSE.
+   * @phpstan-param array<string, mixed> $extraParams
    *
    * @throws \CRM_Core_Exception
    */
-  public function countEntities(string $entityName, ConditionInterface $where, array $options = []): int;
+  public function countEntities(string $entityName, ConditionInterface $where, array $extraParams = []): int;
 
   /**
    * @param array<string, mixed|ApiParameterInterface> $params
@@ -49,12 +48,11 @@ interface Api4Interface {
 
   /**
    * @phpstan-param array<string, mixed> $values
-   * @phpstan-param array{checkPermissions?: bool} $options
-   *   checkPermissions defaults to FALSE.
+   * @phpstan-param array<string, mixed> $extraParams
    *
    * @throws \CRM_Core_Exception
    */
-  public function createEntity(string $entityName, array $values, array $options = []): Result;
+  public function createEntity(string $entityName, array $values, array $extraParams = []): Result;
 
   /**
    * @return \Civi\Api4\Generic\AbstractGetAction
@@ -66,20 +64,18 @@ interface Api4Interface {
   public function createGetAction(string $entityName): AbstractAction;
 
   /**
-   * @phpstan-param array{checkPermissions?: bool} $options
-   *   checkPermissions defaults to FALSE.
+   * @phpstan-param array<string, mixed> $extraParams
    *
    * @throws \CRM_Core_Exception
    */
-  public function deleteEntities(string $entityName, ConditionInterface $condition, array $options = []): Result;
+  public function deleteEntities(string $entityName, ConditionInterface $condition, array $extraParams = []): Result;
 
   /**
-   * @phpstan-param array{checkPermissions?: bool} $options
-   *   checkPermissions defaults to FALSE.
+   * @phpstan-param array<string, mixed> $extraParams
    *
    * @throws \CRM_Core_Exception
    */
-  public function deleteEntity(string $entityName, int $id, array $options = []): Result;
+  public function deleteEntity(string $entityName, int $id, array $extraParams = []): Result;
 
   /**
    * @param array<string, mixed|ApiParameterInterface> $params
@@ -109,22 +105,20 @@ interface Api4Interface {
   ): Result;
 
   /**
-   * @phpstan-param array{checkPermissions?: bool} $options
-   *   checkPermissions defaults to FALSE.
+   * @phpstan-param array<string, mixed> $extraParams
    *
    * @phpstan-return array<string, mixed>|null
    *
    * @throws \CRM_Core_Exception
    */
-  public function getEntity(string $entityName, int $id, array $options = []): ?array;
+  public function getEntity(string $entityName, int $id, array $extraParams = []): ?array;
 
   /**
    * @phpstan-param array<string, mixed> $values
-   * @phpstan-param array{checkPermissions?: bool} $options
-   *   checkPermissions defaults to FALSE.
+   * @phpstan-param array<string, mixed> $extraParams
    *
    * @throws \CRM_Core_Exception
    */
-  public function updateEntity(string $entityName, int $id, array $values, array $options = []): Result;
+  public function updateEntity(string $entityName, int $id, array $values, array $extraParams = []): Result;
 
 }


### PR DESCRIPTION
Previously some methods only accepted a restricted set of additional API parameters (options), now any additional API parameter is allowed.

systopia-reference: 20579