### PR TITLE
Add support for limited validation

### DIFF
--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormInput.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormInput.php
@@ -20,6 +20,8 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\Form\FormSpec;
 
 /**
+ * @phpstan-import-type limitValidationT from FormSpec
+ *
  * @api
  */
 abstract class AbstractFormInput implements FormElementInterface {
@@ -29,6 +31,11 @@ abstract class AbstractFormInput implements FormElementInterface {
   private string $label;
 
   private string $description = '';
+
+  /**
+   * @phpstan-var limitValidationT
+   */
+  private $limitValidation = NULL;
 
   public function __construct(string $name, string $label) {
     $this->name = $name;
@@ -74,6 +81,32 @@ abstract class AbstractFormInput implements FormElementInterface {
    */
   public function setDescription(string $description): self {
     $this->description = $description;
+
+    return $this;
+  }
+
+  /**
+   * @phpstan-return limitValidationT
+   *   Condition for usage of limited validation. Limited validation can be used
+   *   to persist forms in an incomplete state. See definition of
+   *   "limitValidationT" for possible values.
+   */
+  public function getLimitValidation() {
+    return $this->limitValidation;
+  }
+
+  /**
+   * @phpstan-param limitValidationT $limitValidation
+   *   Condition for usage of limited validation. Limited validation can be used
+   *   to persist forms in an incomplete state. With limited validation some
+   *   validations are not performed, but it is for example ensured that the
+   *   data type matches if a value is given, and that strings don't exceed a
+   *   possible maximum length. See definition of "limitValidationT" for
+   *   possible values. Might be set to false to enforce normal validation for
+   *   this input if limited validation is configured in FormSpec.
+   */
+  public function setLimitValidation($limitValidation): self {
+    $this->limitValidation = $limitValidation;
 
     return $this;
   }

--- a/Civi/RemoteTools/Form/FormSpec/Field/AbstractTextField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/AbstractTextField.php
@@ -54,6 +54,10 @@ abstract class AbstractTextField extends AbstractFormField {
   }
 
   public function getMinLength(): ?int {
+    if ($this->isRequired()) {
+      return $this->minLength ?? 1;
+    }
+
     return $this->minLength;
   }
 

--- a/Civi/RemoteTools/Form/FormSpec/FormSpec.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormSpec.php
@@ -22,11 +22,41 @@ namespace Civi\RemoteTools\Form\FormSpec;
 /**
  * @extends AbstractFormElementContainer<FormElementInterface>
  *
+ * @phpstan-type fieldNameT string
+ * @phpstan-type fieldValueT scalar|null
+ * @phpstan-type operatorT '='|'!='|'>'|'>='|'<'|'<='|'=~'|'IN'|'NOT IN'
+ *   "=~" can be used for regex comparison. (Patterns must not be enclosed by a
+ *   character.)
+ * @phpstan-type expressionT string
+ *   Expression in Symfony Expression Language syntax. Form fields can be
+ *   referenced in this form: @{field}
+ * @phpstan-type fieldNameValuePairsT non-empty-array<fieldNameT, fieldValueT|list<fieldValueT>>
+ *   Field must equal the given values or one of the given values.
+ * @phpstan-type conditionListT non-empty-list<array{fieldNameT, operatorT, fieldValueT|list<fieldValueT>}>
+ *   List of conditions with field name, operator, and value. For the operators
+ *   "IN" and "NOT IN" a list of values has to be given.
+ * @phpstan-type limitValidationT null|bool|fieldNameValuePairsT|conditionListT|expressionT
+ *   - null (default): Limited validation is disabled when used in FormSpec.
+ *     Configuration of FormSpec is applied when used in form input.
+ *   - false: Limited validation is disabled. Can be used in form input when
+ *     limited validation is configured in FormSpec to enforce normal validation
+ *     for this input.
+ *   - true: Limited validation is enabled. (Probably not necessary.)
+ *   - fieldNameValuePairsT: Limited validation is used if all given fields
+ *     match.
+ *   - conditionListT: Limited validation is used if all conditions are matched.
+ *   - expressionT: Limited validation is used if expression is matched.
+ *
  * @api
  */
 final class FormSpec extends AbstractFormElementContainer {
 
   private ?DataTransformerInterface $dataTransformer = NULL;
+
+  /**
+   * @phpstan-var limitValidationT
+   */
+  private $limitValidation = NULL;
 
   /**
    * @phpstan-var array<ValidatorInterface>
@@ -40,6 +70,35 @@ final class FormSpec extends AbstractFormElementContainer {
 
   public function setDataTransformer(DataTransformerInterface $dataTransformer): self {
     $this->dataTransformer = $dataTransformer;
+
+    return $this;
+  }
+
+  /**
+   * @phpstan-return limitValidationT
+   *   Condition for usage of limited validation. Limited validation can be used
+   *   to persist forms in an incomplete state. See definition of
+   *   "limitValidationT" for possible values.
+   */
+  public function getLimitValidation() {
+    return $this->limitValidation;
+  }
+
+  /**
+   * @phpstan-param limitValidationT $limitValidation
+   *   Condition for usage of limited validation. Limited validation can be used
+   *   to persist forms in an incomplete state. With limited validation some
+   *   validations are not performed, but it is for example ensured that the
+   *   data type matches if a value is given, and that strings don't exceed a
+   *   possible maximum length. See definition of "limitValidationT" for
+   *   possible values.
+   *
+   *   Example: ['_action' => 'save']
+   *   If "_action" is the name of the submit buttons and the submit button
+   *   with the value "save" is pressed then limited validation is performed.
+   */
+  public function setLimitValidation($limitValidation): self {
+    $this->limitValidation = $limitValidation;
 
     return $this;
   }

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/AbstractFieldJsonSchemaFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/AbstractFieldJsonSchemaFactory.php
@@ -19,12 +19,27 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\JsonSchema\FormSpec\Factory;
 
+use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
 use Civi\RemoteTools\JsonSchema\FormSpec\FieldJsonSchemaFactoryInterface;
+use Civi\RemoteTools\JsonSchema\FormSpec\LimitValidationSchemaFactory;
+use Civi\RemoteTools\JsonSchema\JsonSchema;
 
 abstract class AbstractFieldJsonSchemaFactory implements FieldJsonSchemaFactoryInterface {
 
   public static function getPriority(): int {
     return 0;
   }
+
+  public function createSchema(AbstractFormField $field): JsonSchema {
+    $schema = $this->doCreateSchema($field);
+
+    if (NULL !== $field->getLimitValidation()) {
+      $schema['$limitValidation'] = LimitValidationSchemaFactory::createSchema($field->getLimitValidation());
+    }
+
+    return $schema;
+  }
+
+  abstract protected function doCreateSchema(AbstractFormField $field): JsonSchema;
 
 }

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/BooleanFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/BooleanFieldFactory.php
@@ -25,7 +25,7 @@ use Civi\RemoteTools\JsonSchema\JsonSchemaBoolean;
 
 final class BooleanFieldFactory extends AbstractFieldJsonSchemaFactory {
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     $keywords = [];
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateFieldFactory.php
@@ -25,7 +25,7 @@ use Civi\RemoteTools\JsonSchema\JsonSchemaString;
 
 final class DateFieldFactory extends AbstractFieldJsonSchemaFactory {
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     $keywords = ['format' => 'date'];
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateTimeFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateTimeFieldFactory.php
@@ -25,7 +25,7 @@ use Civi\RemoteTools\JsonSchema\JsonSchemaString;
 
 final class DateTimeFieldFactory extends AbstractFieldJsonSchemaFactory {
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     $keywords = ['format' => 'date-time'];
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/FileFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/FileFieldFactory.php
@@ -31,7 +31,7 @@ final class FileFieldFactory extends AbstractFieldJsonSchemaFactory {
     return IntegerFieldFactory::getPriority() + 1;
   }
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     Assert::isInstanceOf($field, FileField::class);
     /** @var \Civi\RemoteTools\Form\FormSpec\Field\FileField $field */
 

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/IntegerFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/IntegerFieldFactory.php
@@ -26,7 +26,7 @@ use Civi\RemoteTools\JsonSchema\JsonSchemaInteger;
 
 final class IntegerFieldFactory extends AbstractFieldJsonSchemaFactory {
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     $keywords = [];
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/MultiOptionFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/MultiOptionFieldFactory.php
@@ -28,7 +28,7 @@ use Webmozart\Assert\Assert;
 
 final class MultiOptionFieldFactory extends AbstractFieldJsonSchemaFactory {
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     Assert::isInstanceOf($field, AbstractMultiOptionField::class);
     /** @var \Civi\RemoteTools\Form\FormSpec\Field\AbstractMultiOptionField $field */
 

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/NumberFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/NumberFieldFactory.php
@@ -31,7 +31,7 @@ final class NumberFieldFactory extends AbstractFieldJsonSchemaFactory {
     return -1;
   }
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     $keywords = [];
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/OptionFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/OptionFieldFactory.php
@@ -27,7 +27,7 @@ use Webmozart\Assert\Assert;
 
 final class OptionFieldFactory extends AbstractFieldJsonSchemaFactory {
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     Assert::isInstanceOf($field, AbstractOptionField::class);
     /** @var \Civi\RemoteTools\Form\FormSpec\Field\AbstractOptionField $field */
     $keywords = [

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/StringFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/StringFieldFactory.php
@@ -30,7 +30,7 @@ final class StringFieldFactory extends AbstractFieldJsonSchemaFactory {
     return -1;
   }
 
-  public function createSchema(AbstractFormField $field): JsonSchema {
+  protected function doCreateSchema(AbstractFormField $field): JsonSchema {
     $keywords = [];
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();

--- a/Civi/RemoteTools/JsonSchema/FormSpec/JsonSchemaFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/JsonSchemaFactory.php
@@ -83,6 +83,10 @@ final class JsonSchemaFactory implements JsonSchemaFactoryInterface {
       $keywords['oneOf'] = $oneOf;
     }
 
+    if (NULL !== $formSpec->getLimitValidation()) {
+      $keywords['$limitValidation'] = LimitValidationSchemaFactory::createSchema($formSpec->getLimitValidation());
+    }
+
     return new JsonSchemaObject($properties, $keywords);
   }
 

--- a/Civi/RemoteTools/JsonSchema/FormSpec/LimitValidationSchemaFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/LimitValidationSchemaFactory.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\JsonSchema\FormSpec;
+
+use Civi\RemoteTools\JsonSchema\JsonSchema;
+
+/**
+ * @phpstan-import-type conditionListT from \Civi\RemoteTools\Form\FormSpec\FormSpec
+ * @phpstan-import-type fieldNameValuePairsT from \Civi\RemoteTools\Form\FormSpec\FormSpec
+ * @phpstan-import-type limitValidationT from \Civi\RemoteTools\Form\FormSpec\FormSpec
+ */
+final class LimitValidationSchemaFactory {
+
+  /**
+   * @phpstan-param limitValidationT $limitValidation
+   */
+  public static function createSchema($limitValidation): ?JsonSchema {
+    $condition = self::createCondition($limitValidation);
+
+    if (NULL === $condition) {
+      return NULL;
+    }
+
+    if (FALSE === $condition) {
+      return JsonSchema::fromArray([
+        'condition' => FALSE,
+      ]);
+    }
+
+    return JsonSchema::fromArray([
+      'condition' => $condition,
+      'rules' => [
+        [
+          'keyword' => ['const' => 'required'],
+          'validate' => TRUE,
+        ],
+      ],
+    ]);
+  }
+
+  /**
+   * @phpstan-param conditionListT $conditionList
+   *
+   * phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh
+   */
+  private static function createConditionFromConditionList(array $conditionList): JsonSchema {
+    // phpcs:enable
+    $properties = [];
+    foreach ($conditionList as [$fieldName, $operator, $value]) {
+      switch ($operator) {
+        case '=':
+          $properties[$fieldName]['const'] = $value;
+          break;
+
+        case '!=':
+          $properties[$fieldName]['not']['const'] = $value;
+          break;
+
+        case '>':
+          if (!is_int($value) && !is_float($value)) {
+            throw new \InvalidArgumentException('Expected integer or float for operator ">", got ' . gettype($value));
+          }
+
+          $properties[$fieldName]['exclusiveMinimum'] = $value;
+          break;
+
+        case '>=':
+          if (!is_int($value) && !is_float($value)) {
+            throw new \InvalidArgumentException('Expected integer or float for operator ">=", got ' . gettype($value));
+          }
+
+          $properties[$fieldName]['minimum'] = $value;
+          break;
+
+        case '<':
+          if (!is_int($value) && !is_float($value)) {
+            throw new \InvalidArgumentException('Expected integer or float for operator "<", got ' . gettype($value));
+          }
+
+          $properties[$fieldName]['exclusiveMaximum'] = $value;
+          break;
+
+        case '<=':
+          if (!is_int($value) && !is_float($value)) {
+            throw new \InvalidArgumentException('Expected integer or float for operator "<=", got ' . gettype($value));
+          }
+
+          $properties[$fieldName]['maximum'] = $value;
+          break;
+
+        case '=~':
+          if (!is_string($value)) {
+            throw new \InvalidArgumentException('Expected string for operator "=~", got ' . gettype($value));
+          }
+
+          $properties[$fieldName]['pattern'] = $value;
+          break;
+
+        case 'IN':
+          if (!is_array($value)) {
+            throw new \InvalidArgumentException('Expected array for operator "IN", got ' . gettype($value));
+          }
+
+          $properties[$fieldName]['enum'] = $value;
+          break;
+
+        case 'NOT IN':
+          if (!is_array($value)) {
+            throw new \InvalidArgumentException('Expected array for operator "NOT IN", got ' . gettype($value));
+          }
+
+          $properties[$fieldName]['not']['enum'] = $value;
+          break;
+
+        default:
+          throw new \InvalidArgumentException(sprintf('Unknown operator "%s"', $operator));
+      }
+    }
+
+    return JsonSchema::fromArray(['properties' => $properties]);
+  }
+
+  /**
+   * @phpstan-param fieldNameValuePairsT $fieldNameValuePairs
+   */
+  private static function createConditionFromPairs(array $fieldNameValuePairs): JsonSchema {
+    $properties = array_map(
+      fn ($value) => is_array($value) ? ['enum' => $value] : ['const' => $value],
+      $fieldNameValuePairs
+    );
+
+    return JsonSchema::fromArray(['properties' => $properties]);
+  }
+
+  /**
+   * @phpstan-param limitValidationT $limitValidation
+   *
+   * @return bool|null|JsonSchema
+   */
+  private static function createCondition($limitValidation) {
+    if (NULL === $limitValidation) {
+      return NULL;
+    }
+
+    if (is_bool($limitValidation)) {
+      return $limitValidation;
+    }
+
+    if (is_string($limitValidation)) {
+      return self::createValidateCondition($limitValidation);
+    }
+
+    if (is_array($limitValidation)) {
+      if (is_string(key($limitValidation))) {
+        /** @phpstan-var fieldNameValuePairsT $limitValidation */
+        return self::createConditionFromPairs($limitValidation);
+      }
+
+      /** @phpstan-var conditionListT $limitValidation */
+      return self::createConditionFromConditionList($limitValidation);
+    }
+
+    throw new \InvalidArgumentException('Unsupported limit validation specification');
+  }
+
+  private static function createValidateCondition(string $expression): JsonSchema {
+    $variables = [];
+
+    $expression = preg_replace_callback(
+      '/@{([^\s}]+)}/',
+      function (array $match) use (&$variables) {
+        $variables[$match[1]] = ['$data' => '/' . $match[1]];
+
+        return $match[1];
+      },
+      $expression
+    );
+
+    return JsonSchema::fromArray([
+      'evaluate' => [
+        'expression' => $expression,
+        'variables' => $variables,
+      ],
+    ]);
+  }
+
+}

--- a/tests/phpunit/Civi/RemoteTools/JsonSchema/FormSpec/LimitValidationSchemaFactoryTest.php
+++ b/tests/phpunit/Civi/RemoteTools/JsonSchema/FormSpec/LimitValidationSchemaFactoryTest.php
@@ -1,0 +1,149 @@
+<?php
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\JsonSchema\FormSpec;
+
+use Civi\RemoteTools\JsonSchema\JsonSchema;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\RemoteTools\JsonSchema\FormSpec\LimitValidationSchemaFactory
+ */
+final class LimitValidationSchemaFactoryTest extends TestCase {
+
+  private const EXPECTED_RULE = [
+    'keyword' => ['const' => 'required'],
+    'validate' => TRUE,
+  ];
+
+  public function testNull(): void {
+    static::assertNull(LimitValidationSchemaFactory::createSchema(NULL));
+  }
+
+  public function testFalse(): void {
+    $schema = LimitValidationSchemaFactory::createSchema(FALSE);
+    static::assertNotNull($schema);
+    static::assertEquals([
+      'condition' => FALSE,
+    ], $schema->toArray());
+  }
+
+  public function testTrue(): void {
+    $schema = LimitValidationSchemaFactory::createSchema(TRUE);
+    static::assertNotNull($schema);
+    static::assertEquals([
+      'condition' => TRUE,
+      'rules' => [self::EXPECTED_RULE],
+    ], $schema->toArray());
+  }
+
+  public function testFieldNameValuePairs(): void {
+    $schema = LimitValidationSchemaFactory::createSchema(['foo' => 'bar']);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['const' => 'bar'],
+    ], $schema);
+  }
+
+  public function testFieldNameValuesPairs(): void {
+    $schema = LimitValidationSchemaFactory::createSchema(['foo' => ['bar', 'baz']]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['enum' => ['bar', 'baz']],
+    ], $schema);
+  }
+
+  public function testConditionList(): void {
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', '=', 'bar'],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['const' => 'bar'],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', '!=', 'bar'],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['not' => ['const' => 'bar']],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', '>', 1],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['exclusiveMinimum' => 1],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', '>=', 1],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['minimum' => 1],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', '<', 1],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['exclusiveMaximum' => 1],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', '<=', 1],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['maximum' => 1],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', '=~', 'abc'],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['pattern' => 'abc'],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', 'IN', ['bar', 'baz']],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['enum' => ['bar', 'baz']],
+    ], $schema);
+
+    $schema = LimitValidationSchemaFactory::createSchema([
+      ['foo', 'NOT IN', ['bar', 'baz']],
+    ]);
+    static::assertLimitValidationPropertiesSchema([
+      'foo' => ['not' => ['enum' => ['bar', 'baz']]],
+    ], $schema);
+  }
+
+  public function testExpression(): void {
+    $schema = LimitValidationSchemaFactory::createSchema('@{foo} + @{bar} > 10');
+    static::assertNotNull($schema);
+    static::assertEquals([
+      'condition' => [
+        'evaluate' => [
+          'expression' => 'foo + bar > 10',
+          'variables' => [
+            'foo' => ['$data' => '/foo'],
+            'bar' => ['$data' => '/bar'],
+          ],
+        ],
+      ],
+      'rules' => [self::EXPECTED_RULE],
+    ], $schema->toArray());
+  }
+
+  /**
+   * @phpstan-param array<string, array<string, mixed>> $properties
+   */
+  private static function assertLimitValidationPropertiesSchema(array $properties, ?JsonSchema $schema): void {
+    static::assertNotNull($schema);
+    static::assertEquals([
+      'condition' => [
+        'properties' => $properties,
+      ],
+      'rules' => [self::EXPECTED_RULE],
+    ], $schema->toArray());
+  }
+
+}


### PR DESCRIPTION
Add support for the `$limitValidation` keyword. (See https://github.com/systopia/opis-json-schema-ext?tab=readme-ov-file#limit-validation).

See documentation in `\Civi\RemoteTools\Form\FormSpec\FormSpec` for usage.

Explanation for the chosen form (`@{field}`) to reference fields in an expression condition for limited validation: Just using curly brackets could be confused with hashes in [Symfony Expression Language](https://symfony.com/doc/current/reference/formats/expression_language.html). For that reason the prefix `@` is used that is not an operator in the expression language. `$` is not used because it could be confused with a PHP variable.

systopia-reference: 28662