### PR TITLE
Allow to set a form rule on form elements to hide/disable them

### DIFF
--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormElement.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormElement.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 SYSTOPIA GmbH
+ * Copyright (C) 2025 SYSTOPIA GmbH
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published by
@@ -21,23 +21,8 @@ namespace Civi\RemoteTools\Form\FormSpec;
 
 use Civi\RemoteTools\Form\FormSpec\Rule\FormRuleTrait;
 
-/**
- * @codeCoverageIgnore
- *
- * @extends AbstractFormElementContainer<FormTab>
- *
- * @api
- */
-class VerticalTabsContainer extends AbstractFormElementContainer implements FormElementInterface {
+abstract class AbstractFormElement implements FormElementInterface {
 
   use FormRuleTrait;
-
-  public function __construct(array $elements = []) {
-    parent::__construct('', $elements);
-  }
-
-  public function getType(): string {
-    return 'vertical_tabs';
-  }
 
 }

--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormInput.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormInput.php
@@ -24,7 +24,7 @@ namespace Civi\RemoteTools\Form\FormSpec;
  *
  * @api
  */
-abstract class AbstractFormInput implements FormElementInterface {
+abstract class AbstractFormInput extends AbstractFormElement {
 
   private string $name;
 

--- a/Civi/RemoteTools/Form/FormSpec/FormElementContainer.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormElementContainer.php
@@ -19,6 +19,8 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Form\FormSpec;
 
+use Civi\RemoteTools\Form\FormSpec\Rule\FormRuleTrait;
+
 /**
  * @codeCoverageIgnore
  *
@@ -27,6 +29,8 @@ namespace Civi\RemoteTools\Form\FormSpec;
  * @api
  */
 class FormElementContainer extends AbstractFormElementContainer implements FormElementInterface {
+
+  use FormRuleTrait;
 
   private bool $collapsible = FALSE;
 

--- a/Civi/RemoteTools/Form/FormSpec/FormElementInterface.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormElementInterface.php
@@ -19,11 +19,20 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Form\FormSpec;
 
+use Civi\RemoteTools\Form\FormSpec\Rule\FormRule;
+
 /**
  * @api
  */
 interface FormElementInterface {
 
   public function getType(): string;
+
+  public function getRule(): ?FormRule;
+
+  /**
+   * @return $this
+   */
+  public function setRule(?FormRule $rule): self;
 
 }

--- a/Civi/RemoteTools/Form/FormSpec/FormTab.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormTab.php
@@ -19,12 +19,16 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Form\FormSpec;
 
+use Civi\RemoteTools\Form\FormSpec\Rule\FormRuleTrait;
+
 /**
  * @codeCoverageIgnore
  *
  * @api
  */
 class FormTab extends AbstractFormElementContainer implements FormElementInterface {
+
+  use FormRuleTrait;
 
   public ?string $description;
 

--- a/Civi/RemoteTools/Form/FormSpec/Markup/HtmlElement.php
+++ b/Civi/RemoteTools/Form/FormSpec/Markup/HtmlElement.php
@@ -19,12 +19,12 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Form\FormSpec\Markup;
 
-use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
+use Civi\RemoteTools\Form\FormSpec\AbstractFormElement;
 
 /**
  * @api
  */
-final class HtmlElement implements FormElementInterface {
+final class HtmlElement extends AbstractFormElement {
 
   private string $content;
 

--- a/Civi/RemoteTools/Form/FormSpec/Other/InternalLinkElement.php
+++ b/Civi/RemoteTools/Form/FormSpec/Other/InternalLinkElement.php
@@ -20,13 +20,13 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Form\FormSpec\Other;
 
-use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
+use Civi\RemoteTools\Form\FormSpec\AbstractFormElement;
 
 /**
  * Displays a link to a CiviCRM resource. The URL is not exposed to users, but
  * the remote system acts as proxy.
  */
-final class InternalLinkElement implements FormElementInterface {
+final class InternalLinkElement extends AbstractFormElement {
 
   private string $url;
 

--- a/Civi/RemoteTools/Form/FormSpec/Rule/FormRule.php
+++ b/Civi/RemoteTools/Form/FormSpec/Rule/FormRule.php
@@ -30,6 +30,7 @@ namespace Civi\RemoteTools\Form\FormSpec\Rule;
  * @phpstan-type effectT 'ENABLE'|'DISABLE'|'SHOW'|'HIDE'
  * @phpstan-type conditionT array{operatorT, valueT}
  * @phpstan-type conditionListT array<fieldNameT, conditionT>
+ *   All conditions have to be met for the effect to be applied.
  *
  * @api
  */

--- a/Civi/RemoteTools/Form/FormSpec/Rule/FormRule.php
+++ b/Civi/RemoteTools/Form/FormSpec/Rule/FormRule.php
@@ -1,0 +1,57 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Form\FormSpec\Rule;
+
+/**
+ * @phpstan-type fieldNameT non-empty-string
+ * @phpstan-type operatorT '='|'!='|'IN'|'NOT IN'|'CONTAINS'|'NOT CONTAINS'
+ *   The (NOT) CONTAINS operator can be used for multi option fields, e.g.
+ *   checkboxes. The value can be a single value or a list of values. The
+ *   selected options need only to contain one of the given values (not all of
+ *   them).
+ * @phpstan-type valueT scalar|list<scalar|null>|null
+ * @phpstan-type effectT 'ENABLE'|'DISABLE'|'SHOW'|'HIDE'
+ * @phpstan-type conditionT array{operatorT, valueT}
+ * @phpstan-type conditionListT array<fieldNameT, conditionT>
+ *
+ * @api
+ */
+final class FormRule {
+
+  /**
+   * @phpstan-var conditionListT
+   */
+  public array $conditions = [];
+
+  /**
+   * @phpstan-var effectT
+   */
+  public string $effect;
+
+  /**
+   * @phpstan-param effectT $effect
+   * @phpstan-param conditionListT $conditions
+   */
+  public function __construct(string $effect, array $conditions) {
+    $this->effect = $effect;
+    $this->conditions = $conditions;
+  }
+
+}

--- a/Civi/RemoteTools/Form/FormSpec/Rule/FormRuleTrait.php
+++ b/Civi/RemoteTools/Form/FormSpec/Rule/FormRuleTrait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 SYSTOPIA GmbH
+ * Copyright (C) 2025 SYSTOPIA GmbH
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU Affero General Public License as published by
@@ -17,27 +17,22 @@
 
 declare(strict_types = 1);
 
-namespace Civi\RemoteTools\Form\FormSpec;
+namespace Civi\RemoteTools\Form\FormSpec\Rule;
 
-use Civi\RemoteTools\Form\FormSpec\Rule\FormRuleTrait;
+use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
 
-/**
- * @codeCoverageIgnore
- *
- * @extends AbstractFormElementContainer<FormTab>
- *
- * @api
- */
-class VerticalTabsContainer extends AbstractFormElementContainer implements FormElementInterface {
+trait FormRuleTrait {
 
-  use FormRuleTrait;
+  private ?FormRule $rule = NULL;
 
-  public function __construct(array $elements = []) {
-    parent::__construct('', $elements);
+  public function getRule(): ?FormRule {
+    return $this->rule;
   }
 
-  public function getType(): string {
-    return 'vertical_tabs';
+  public function setRule(?FormRule $rule): FormElementInterface {
+    $this->rule = $rule;
+
+    return $this;
   }
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/AbstractConcreteElementUiSchemaFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/AbstractConcreteElementUiSchemaFactory.php
@@ -19,12 +19,34 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\JsonForms\FormSpec\Factory;
 
+use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
 use Civi\RemoteTools\JsonForms\FormSpec\ConcreteElementUiSchemaFactoryInterface;
+use Civi\RemoteTools\JsonForms\FormSpec\ElementUiSchemaFactoryInterface;
+use Civi\RemoteTools\JsonForms\FormSpec\RuleFactory;
+use Civi\RemoteTools\JsonForms\JsonFormsElement;
 
 abstract class AbstractConcreteElementUiSchemaFactory implements ConcreteElementUiSchemaFactoryInterface {
 
   public static function getPriority(): int {
     return 0;
   }
+
+  final public function createSchema(
+    FormElementInterface $element,
+    ElementUiSchemaFactoryInterface $factory
+  ): JsonFormsElement {
+    $jsonFormsElement = $this->doCreateSchema($element, $factory);
+
+    if (NULL !== $element->getRule()) {
+      $jsonFormsElement['rule'] = RuleFactory::createJsonFormsRule($element->getRule());
+    }
+
+    return $jsonFormsElement;
+  }
+
+  abstract protected function doCreateSchema(
+    FormElementInterface $element,
+    ElementUiSchemaFactoryInterface $factory
+  ): JsonFormsElement;
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Control/AbstractControlFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Control/AbstractControlFactory.php
@@ -28,7 +28,11 @@ use Webmozart\Assert\Assert;
 
 abstract class AbstractControlFactory extends AbstractConcreteElementUiSchemaFactory {
 
-  final public function createSchema(
+  final public function supportsElement(FormElementInterface $element): bool {
+    return $element instanceof AbstractFormInput && $this->supportsInput($element);
+  }
+
+  final protected function doCreateSchema(
     FormElementInterface $element,
     ElementUiSchemaFactoryInterface $factory
   ): JsonFormsElement {
@@ -36,10 +40,6 @@ abstract class AbstractControlFactory extends AbstractConcreteElementUiSchemaFac
     /** @var \Civi\RemoteTools\Form\FormSpec\AbstractFormInput $element */
 
     return $this->createInputSchema($element, $factory);
-  }
-
-  final public function supportsElement(FormElementInterface $element): bool {
-    return $element instanceof AbstractFormInput && $this->supportsInput($element);
   }
 
   final protected function getScope(AbstractFormInput $field): string {

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Control/HtmlMarkupFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Control/HtmlMarkupFactory.php
@@ -29,7 +29,7 @@ use Webmozart\Assert\Assert;
 
 final class HtmlMarkupFactory extends AbstractConcreteElementUiSchemaFactory {
 
-  public function createSchema(
+  protected function doCreateSchema(
     FormElementInterface $element,
     ElementUiSchemaFactoryInterface $factory
   ): JsonFormsElement {

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategorizationFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategorizationFactory.php
@@ -29,7 +29,11 @@ use Webmozart\Assert\Assert;
 
 final class CategorizationFactory extends AbstractConcreteElementUiSchemaFactory {
 
-  public function createSchema(
+  public function supportsElement(FormElementInterface $element): bool {
+    return $element instanceof VerticalTabsContainer;
+  }
+
+  protected function doCreateSchema(
     FormElementInterface $element,
     ElementUiSchemaFactoryInterface $factory
   ): JsonFormsElement {
@@ -38,10 +42,6 @@ final class CategorizationFactory extends AbstractConcreteElementUiSchemaFactory
     $elements = array_map([$factory, 'createSchema'], $element->getElements());
 
     return new JsonFormsCategorization($elements);
-  }
-
-  public function supportsElement(FormElementInterface $element): bool {
-    return $element instanceof VerticalTabsContainer;
   }
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategoryFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/CategoryFactory.php
@@ -29,7 +29,11 @@ use Webmozart\Assert\Assert;
 
 final class CategoryFactory extends AbstractConcreteElementUiSchemaFactory {
 
-  public function createSchema(
+  public function supportsElement(FormElementInterface $element): bool {
+    return $element instanceof FormTab;
+  }
+
+  protected function doCreateSchema(
     FormElementInterface $element,
     ElementUiSchemaFactoryInterface $factory
   ): JsonFormsElement {
@@ -38,10 +42,6 @@ final class CategoryFactory extends AbstractConcreteElementUiSchemaFactory {
     $elements = array_map([$factory, 'createSchema'], $element->getElements());
 
     return new JsonFormsCategory($element->getTitle(), $elements, $element->getDescription());
-  }
-
-  public function supportsElement(FormElementInterface $element): bool {
-    return $element instanceof FormTab;
   }
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/GroupFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Layout/GroupFactory.php
@@ -30,7 +30,11 @@ use Webmozart\Assert\Assert;
 
 final class GroupFactory extends AbstractConcreteElementUiSchemaFactory {
 
-  public function createSchema(
+  public function supportsElement(FormElementInterface $element): bool {
+    return $element instanceof FormElementContainer;
+  }
+
+  protected function doCreateSchema(
     FormElementInterface $element,
     ElementUiSchemaFactoryInterface $factory
   ): JsonFormsElement {
@@ -43,10 +47,6 @@ final class GroupFactory extends AbstractConcreteElementUiSchemaFactory {
     }
 
     return new JsonFormsGroup($element->getTitle(), $elements, $element->getDescription());
-  }
-
-  public function supportsElement(FormElementInterface $element): bool {
-    return $element instanceof FormElementContainer;
   }
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/Factory/Other/InternalLinkFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/Factory/Other/InternalLinkFactory.php
@@ -31,7 +31,11 @@ use Webmozart\Assert\Assert;
  */
 final class InternalLinkFactory extends AbstractConcreteElementUiSchemaFactory {
 
-  public function createSchema(
+  public function supportsElement(FormElementInterface $element): bool {
+    return $element instanceof InternalLinkElement;
+  }
+
+  protected function doCreateSchema(
     FormElementInterface $element,
     ElementUiSchemaFactoryInterface $factory
   ): JsonFormsElement {
@@ -43,10 +47,6 @@ final class InternalLinkFactory extends AbstractConcreteElementUiSchemaFactory {
       'description' => $element->getDescription(),
       'filename' => $element->getFilename(),
     ]);
-  }
-
-  public function supportsElement(FormElementInterface $element): bool {
-    return $element instanceof InternalLinkElement;
   }
 
 }

--- a/Civi/RemoteTools/JsonForms/FormSpec/RuleFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/RuleFactory.php
@@ -27,8 +27,7 @@ final class RuleFactory {
 
   public static function createJsonFormsRule(FormRule $rule): JsonFormsRule {
     $propertyConditions = [];
-    foreach ($rule->conditions as $fieldName => $condition) {
-      [$operator, $value] = $condition;
+    foreach ($rule->conditions as $fieldName => [$operator, $value]) {
       switch ($operator) {
         case '=':
           $propertyConditions[$fieldName] = ['const' => $value];

--- a/Civi/RemoteTools/JsonForms/FormSpec/RuleFactory.php
+++ b/Civi/RemoteTools/JsonForms/FormSpec/RuleFactory.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\JsonForms\FormSpec;
+
+use Civi\RemoteTools\Form\FormSpec\Rule\FormRule;
+use Civi\RemoteTools\JsonForms\JsonFormsRule;
+use Civi\RemoteTools\JsonSchema\JsonSchema;
+
+final class RuleFactory {
+
+  public static function createJsonFormsRule(FormRule $rule): JsonFormsRule {
+    $propertyConditions = [];
+    foreach ($rule->conditions as $fieldName => $condition) {
+      [$operator, $value] = $condition;
+      switch ($operator) {
+        case '=':
+          $propertyConditions[$fieldName] = ['const' => $value];
+          break;
+
+        case '!=':
+          $propertyConditions[$fieldName] = ['not' => ['const' => $value]];
+          break;
+
+        case 'IN':
+          $propertyConditions[$fieldName] = ['enum' => $value];
+          break;
+
+        case 'NOT IN':
+          $propertyConditions[$fieldName] = ['not' => ['enum' => $value]];
+          break;
+
+        case 'CONTAINS':
+          $propertyConditions[$fieldName] = ['contains' => ['enum' => (array) $value]];
+          break;
+
+        case 'NOT CONTAINS':
+          $propertyConditions[$fieldName] = ['not' => ['contains' => ['enum' => (array) $value]]];
+          break;
+
+        default:
+          throw new \InvalidArgumentException("Unknown rule operator '$operator'");
+      }
+    }
+
+    return new JsonFormsRule(
+      $rule->effect, '#', JsonSchema::fromArray(['properties' => $propertyConditions])
+    );
+  }
+
+}

--- a/tests/phpunit/Civi/RemoteTools/JsonForms/FormSpec/RuleFactoryTest.php
+++ b/tests/phpunit/Civi/RemoteTools/JsonForms/FormSpec/RuleFactoryTest.php
@@ -1,0 +1,127 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\JsonForms\FormSpec;
+
+use Civi\RemoteTools\Form\FormSpec\Rule\FormRule;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\RemoteTools\JsonForms\FormSpec\RuleFactory
+ * @covers \Civi\RemoteTools\Form\FormSpec\Rule\FormRule
+ */
+final class RuleFactoryTest extends TestCase {
+
+  public function testEquals(): void {
+    $ruleSchema = RuleFactory::createJsonFormsRule(new FormRule('SHOW', ['foo' => ['=', 'bar']]));
+
+    static::assertEquals([
+      'effect' => 'SHOW',
+      'condition' => [
+        'scope' => '#',
+        'schema' => [
+          'properties' => [
+            'foo' => ['const' => 'bar'],
+          ],
+        ],
+      ],
+    ], $ruleSchema->toArray());
+  }
+
+  public function testNotEquals(): void {
+    $ruleSchema = RuleFactory::createJsonFormsRule(new FormRule('HIDE', ['foo' => ['!=', 'bar']]));
+
+    static::assertEquals([
+      'effect' => 'HIDE',
+      'condition' => [
+        'scope' => '#',
+        'schema' => [
+          'properties' => [
+            'foo' => ['not' => ['const' => 'bar']],
+          ],
+        ],
+      ],
+    ], $ruleSchema->toArray());
+  }
+
+  public function testIn(): void {
+    $ruleSchema = RuleFactory::createJsonFormsRule(new FormRule('ENABLE', ['foo' => ['IN', ['bar', 'baz']]]));
+
+    static::assertEquals([
+      'effect' => 'ENABLE',
+      'condition' => [
+        'scope' => '#',
+        'schema' => [
+          'properties' => [
+            'foo' => ['enum' => ['bar', 'baz']],
+          ],
+        ],
+      ],
+    ], $ruleSchema->toArray());
+  }
+
+  public function testNotIn(): void {
+    $ruleSchema = RuleFactory::createJsonFormsRule(new FormRule('DISABLE', ['foo' => ['NOT IN', ['bar', 'baz']]]));
+
+    static::assertEquals([
+      'effect' => 'DISABLE',
+      'condition' => [
+        'scope' => '#',
+        'schema' => [
+          'properties' => [
+            'foo' => ['not' => ['enum' => ['bar', 'baz']]],
+          ],
+        ],
+      ],
+    ], $ruleSchema->toArray());
+  }
+
+  public function testContains(): void {
+    $ruleSchema = RuleFactory::createJsonFormsRule(new FormRule('SHOW', ['foo' => ['CONTAINS', ['bar', 'baz']]]));
+
+    static::assertEquals([
+      'effect' => 'SHOW',
+      'condition' => [
+        'scope' => '#',
+        'schema' => [
+          'properties' => [
+            'foo' => ['contains' => ['enum' => ['bar', 'baz']]],
+          ],
+        ],
+      ],
+    ], $ruleSchema->toArray());
+  }
+
+  public function testNotContains(): void {
+    $ruleSchema = RuleFactory::createJsonFormsRule(new FormRule('SHOW', ['foo' => ['NOT CONTAINS', ['bar', 'baz']]]));
+
+    static::assertEquals([
+      'effect' => 'SHOW',
+      'condition' => [
+        'scope' => '#',
+        'schema' => [
+          'properties' => [
+            'foo' => ['not' => ['contains' => ['enum' => ['bar', 'baz']]]],
+          ],
+        ],
+      ],
+    ], $ruleSchema->toArray());
+  }
+
+}


### PR DESCRIPTION
The conditions of a form rule specify which values other fields must (not) have to apply the effect (show, hide, enable, disable).

When converting a `\Civi\RemoteTools\Form\FormSpec\Rule\FormRule` to JSON Forms it results in an object as described [here](https://jsonforms.io/docs/uischema/rules).

systopia-reference: 29078