### PR TITLE
Require PHP ^8.1 and add type hints that weren't possible in PHP 7.4

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -6,6 +6,7 @@ on:
       - '**.php'
       - tools/phpcs/composer.json
       - phpcs.xml.dist
+      - .github/workflows/phpcs.yml
 
 jobs:
   phpcs:
@@ -13,7 +14,7 @@ jobs:
     name: PHP_CodeSniffer
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -29,7 +30,7 @@ jobs:
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ hashFiles('tools/phpcs/composer.json') }}

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -9,18 +9,19 @@ on:
       - ci/composer.json
       - phpstan.ci.neon
       - phpstan.neon.dist
+      - .github/workflows/phpstan.yml
 
 jobs:
   phpstan:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.3']
+        php-versions: ['8.1', '8.4']
         prefer: ['prefer-stable', 'prefer-lowest']
     name: PHPStan with PHP ${{ matrix.php-versions }} ${{ matrix.prefer }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -35,7 +36,7 @@ jobs:
       run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ${{ steps.composer-cache.outputs.dir }}
         key: ${{ runner.os }}-composer-${{ matrix.prefer }}-${{ hashFiles('**/composer.json') }}
@@ -43,7 +44,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        [ "${{ matrix.php-versions }}" = "7.4" ] || [ "${{ matrix.php-versions }}" = "8.0" ] || composer require --no-update 'symfony/html-sanitizer:>=6'
         composer update --no-progress --prefer-dist --${{ matrix.prefer }} --optimize-autoloader &&
         composer composer-phpunit -- update --no-progress --prefer-dist &&
         composer composer-phpstan -- update --no-progress --prefer-dist --optimize-autoloader &&

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,13 +19,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        civicrm-image-tags: [ 'drupal', '5.57-drupal-php8.0' ]
+        civicrm-image-tags: [ 'drupal', '5.57-drupal-php8.1' ]
     name: PHPUnit with Docker image michaelmcandrew/civicrm:${{ matrix.civicrm-image-tags }}
     env:
       CIVICRM_IMAGE_TAG: ${{ matrix.civicrm-image-tags }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Pull images
       run: docker compose -f tests/docker-compose.yml pull --quiet
     - name: Start containers

--- a/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandler.php
+++ b/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandler.php
@@ -103,6 +103,7 @@ abstract class AbstractProfileEntityActionsHandler implements RemoteEntityAction
       ->setLimit($action->getLimit())
       ->setOffset($action->getOffset())
       ->setOrderBy($action->getOrderBy())
+      // @phpstan-ignore argument.type
       ->setSelect($action->getSelect())
       ->setWhere($action->getWhere())
       ->apply($remoteFields);

--- a/Civi/RemoteTools/ActionHandler/DefaultActionHandler.php
+++ b/Civi/RemoteTools/ActionHandler/DefaultActionHandler.php
@@ -20,6 +20,7 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\ActionHandler;
 
 use Civi\Api4\Generic\AbstractAction;
+use Civi\Api4\Generic\Result;
 use Civi\RemoteTools\Exception\ActionHandlerNotFoundException;
 use Webmozart\Assert\Assert;
 
@@ -38,7 +39,7 @@ final class DefaultActionHandler implements ActionHandlerInterface {
    *
    * @throws \Civi\RemoteTools\Exception\ActionHandlerNotFoundException
    */
-  public function __call(string $name, array $arguments) {
+  public function __call(string $name, array $arguments): array|Result {
     $action = $arguments[0] ?? NULL;
     Assert::isInstanceOf($action, AbstractAction::class);
 

--- a/Civi/RemoteTools/Api4/Action/AbstractRemoteGetFieldsAction.php
+++ b/Civi/RemoteTools/Api4/Action/AbstractRemoteGetFieldsAction.php
@@ -48,6 +48,7 @@ abstract class AbstractRemoteGetFieldsAction extends BasicGetFieldsAction implem
     $originalSelect = $this->getSelect();
     if ([] !== $this->getSelect()) {
       $this->setSelect(array_unique(
+        // @phpstan-ignore argument.type
         array_merge($this->getSelect(), WhereUtil::getFields($this->getWhere()))
       ));
     }

--- a/Civi/RemoteTools/Api4/Action/Traits/ActionHandlerTrait.php
+++ b/Civi/RemoteTools/Api4/Action/Traits/ActionHandlerTrait.php
@@ -19,6 +19,7 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Api4\Action\Traits;
 
+use Civi\Api4\Generic\Result;
 use Civi\RemoteTools\ActionHandler\ActionHandlerInterface;
 use Civi\RemoteTools\Exception\ActionHandlerNotFoundException;
 
@@ -39,7 +40,7 @@ trait ActionHandlerTrait {
   public function __construct(
           string $entityName,
           string $actionName,
-          ActionHandlerInterface $actionHandler = NULL
+          ?ActionHandlerInterface $actionHandler = NULL
   ) {
     parent::__construct($entityName, $actionName);
     $this->actionHandler = $actionHandler;
@@ -72,7 +73,7 @@ trait ActionHandlerTrait {
    *   If no exception handler is found and attribute
    *   _ignoreMissingActionHandler is FALSE.
    */
-  protected function getHandlerResult() {
+  protected function getHandlerResult(): array|Result {
     if (!$this->_ignoreMissingActionHandler) {
       // @phpstan-ignore-next-line
       return $this->getActionHandler()->{$this->getActionName()}($this);

--- a/Civi/RemoteTools/Api4/Action/Traits/ArgumentsParameterOptionalTrait.php
+++ b/Civi/RemoteTools/Api4/Action/Traits/ArgumentsParameterOptionalTrait.php
@@ -21,7 +21,7 @@ namespace Civi\RemoteTools\Api4\Action\Traits;
 
 /**
  * @method array<int|string, mixed> getArguments()
- * @method $this setArguments(array $arguments)
+ * @method $this setArguments(array<int|string, mixed> $arguments)
  *
  * @api
  */

--- a/Civi/RemoteTools/Api4/Action/Traits/DataParameterTrait.php
+++ b/Civi/RemoteTools/Api4/Action/Traits/DataParameterTrait.php
@@ -21,7 +21,7 @@ namespace Civi\RemoteTools\Api4\Action\Traits;
 
 /**
  * @method array<string, mixed> getData()
- * @method $this setData(array $data)
+ * @method $this setData(array<string, mixed> $data)
  *
  * @api
  */

--- a/Civi/RemoteTools/Api4/Query/Comparison.php
+++ b/Civi/RemoteTools/Api4/Query/Comparison.php
@@ -20,7 +20,7 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\Api4\Query;
 
 /**
- * @phpstan-type comparisonT array{string, string, 2?: scalar|non-empty-array<scalar>}
+ * @phpstan-type comparisonT array{string, string, 2?: scalar|non-empty-list<scalar>}
  *
  * @api
  */
@@ -31,27 +31,27 @@ final class Comparison implements ConditionInterface {
   private string $operator;
 
   /**
-   * @var scalar|non-empty-array<int, scalar>|null
+   * @var scalar|non-empty-list<scalar>|null
    */
   private $value;
 
   /**
    * @param string $field
    * @param string $operator '=' and '!=' are allowed with NULL as value.
-   * @param scalar|non-empty-array<int, scalar>|null $value
+   * @param scalar|non-empty-list<scalar>|null $value
    *
    * @return self
    */
-  public static function new(string $field, string $operator, $value): self {
+  public static function new(string $field, string $operator, bool|float|int|string|array|null $value): self {
     return new self($field, $operator, $value);
   }
 
   /**
    * @param string $field
    * @param string $operator '=' and '!=' are allowed with NULL as value.
-   * @param scalar|non-empty-array<int, scalar>|null $value
+   * @param scalar|non-empty-list<scalar>|null $value
    */
-  public function __construct(string $field, string $operator, $value) {
+  public function __construct(string $field, string $operator, bool|float|int|string|array|null $value) {
     $this->field = $field;
     $this->operator = $operator;
     $this->value = $value;
@@ -66,9 +66,9 @@ final class Comparison implements ConditionInterface {
   }
 
   /**
-   * @return scalar|non-empty-array<int, scalar>|null
+   * @return scalar|non-empty-list<scalar>|null
    */
-  public function getValue() {
+  public function getValue(): bool|int|string|float|array|null {
     return $this->value;
   }
 

--- a/Civi/RemoteTools/Api4/Query/JoinParameter.php
+++ b/Civi/RemoteTools/Api4/Query/JoinParameter.php
@@ -27,7 +27,7 @@ use Civi\RemoteTools\Api4\ApiParameterInterface;
 final class JoinParameter implements ApiParameterInterface {
 
   /**
-   * @var array<Join>
+   * @var list<Join>
    */
   private array $joins;
 
@@ -36,11 +36,12 @@ final class JoinParameter implements ApiParameterInterface {
   }
 
   public function __construct(Join ...$joins) {
+    /** @var list<Join> $joins */
     $this->joins = $joins;
   }
 
   /**
-   * @return array<Join>
+   * @return list<Join>
    */
   public function getJoins(): array {
     return $this->joins;

--- a/Civi/RemoteTools/Api4/Query/QueryApplier.php
+++ b/Civi/RemoteTools/Api4/Query/QueryApplier.php
@@ -36,7 +36,7 @@ final class QueryApplier {
   private int $offset = 0;
 
   /**
-   * @phpstan-var array<string>
+   * @phpstan-var array<string, string>
    */
   private array $orderBy = [];
 
@@ -46,7 +46,7 @@ final class QueryApplier {
   private array $where = [];
 
   /**
-   * @phpstan-var array<string>
+   * @phpstan-var list<string>
    */
   private array $select = [];
 
@@ -89,14 +89,14 @@ final class QueryApplier {
   }
 
   /**
-   * @phpstan-return array<string>
+   * @phpstan-return array<string, string>
    */
   public function getOrderBy(): array {
     return $this->orderBy;
   }
 
   /**
-   * @phpstan-param array<string> $orderBy
+   * @phpstan-param array<string, string> $orderBy
    */
   public function setOrderBy(array $orderBy): self {
     $this->orderBy = $orderBy;
@@ -105,7 +105,7 @@ final class QueryApplier {
   }
 
   /**
-   * @phpstan-return array<string>
+   * @phpstan-return list<string>
    */
   public function getSelect(): array {
     return $this->select;
@@ -128,7 +128,7 @@ final class QueryApplier {
   }
 
   /**
-   * @phpstan-param array<string> $select
+   * @phpstan-param list<string> $select
    */
   public function setSelect(array $select): self {
     $this->select = $select;
@@ -139,16 +139,16 @@ final class QueryApplier {
   /**
    * @phpstan-param array<array<string, mixed>> $values
    *
-   * @phpstan-return array<string>
+   * @phpstan-return list<string>
    *   All field names that are not names of joined fields or pseudo constants.
    *   This method assumes that all entries in $values have the same array keys.
    */
   private function getStandardFieldNames(array $values): array {
-    return array_filter(
+    return array_values(array_filter(
       // @phpstan-ignore-next-line
       array_keys(reset($values) ?: []),
       fn (string $fieldName) => !str_contains('.', $fieldName) && !str_contains(':', $fieldName)
-    );
+    ));
   }
 
 }

--- a/Civi/RemoteTools/Api4/Query/WhereParameter.php
+++ b/Civi/RemoteTools/Api4/Query/WhereParameter.php
@@ -27,7 +27,7 @@ use Civi\RemoteTools\Api4\ApiParameterInterface;
 final class WhereParameter implements ApiParameterInterface {
 
   /**
-   * @var array<ConditionInterface>
+   * @var list<ConditionInterface>
    */
   private array $conditions;
 
@@ -46,11 +46,12 @@ final class WhereParameter implements ApiParameterInterface {
    *   The conditions are linked by AND.
    */
   public function __construct(ConditionInterface ...$conditions) {
+    /** @var list<ConditionInterface> $conditions */
     $this->conditions = $conditions;
   }
 
   /**
-   * @return array<ConditionInterface> The conditions are linked by AND.
+   * @return list<ConditionInterface> The conditions are linked by AND.
    */
   public function getConditions(): array {
     return $this->conditions;

--- a/Civi/RemoteTools/Api4/Util/SelectUtil.php
+++ b/Civi/RemoteTools/Api4/Util/SelectUtil.php
@@ -25,9 +25,9 @@ namespace Civi\RemoteTools\Api4\Util;
 final class SelectUtil {
 
   /**
-   * @phpstan-param array<string> $select
+   * @phpstan-param list<string> $select
    *
-   * @phpstan-return array<string>
+   * @phpstan-return list<string>
    */
   public static function ensureFieldSelected(string $field, array $select): array {
     if (!self::isFieldSelected($field, $select)) {
@@ -46,7 +46,7 @@ final class SelectUtil {
    * returns TRUE if $select is empty and $field is not from a joined entity
    * (i.e. contains no "." or ":").
    *
-   * @phpstan-param array<string> $select
+   * @phpstan-param list<string> $select
    */
   public static function isFieldSelected(string $field, array $select): bool {
     return [] === $select && !FieldUtil::isJoinedField($field)

--- a/Civi/RemoteTools/Api4/Util/WhereUtil.php
+++ b/Civi/RemoteTools/Api4/Util/WhereUtil.php
@@ -32,7 +32,7 @@ final class WhereUtil {
   /**
    * @phpstan-param whereT $where
    *
-   * @phpstan-return array<string>
+   * @phpstan-return list<string>
    *   Field names used in where.
    */
   public static function getFields(array $where): array {
@@ -49,7 +49,7 @@ final class WhereUtil {
       }
     }
 
-    return array_unique($fields);
+    return array_values(array_unique($fields));
   }
 
 }

--- a/Civi/RemoteTools/Contact/IdentityTrackerRemoteContactIdResolver.php
+++ b/Civi/RemoteTools/Contact/IdentityTrackerRemoteContactIdResolver.php
@@ -36,7 +36,7 @@ final class IdentityTrackerRemoteContactIdResolver implements RemoteContactIdRes
   /**
    * @inheritDoc
    */
-  public function getContactId($remoteAuthenticationToken): int {
+  public function getContactId(int|string $remoteAuthenticationToken): int {
     try {
       /** @var array<string, mixed>&array{id: int, values: array<int, array{id: int}>} $result */
       $result = $this->api3->execute('Contact', 'identify', [

--- a/Civi/RemoteTools/Contact/RemoteContactIdResolverInterface.php
+++ b/Civi/RemoteTools/Contact/RemoteContactIdResolverInterface.php
@@ -22,13 +22,9 @@ namespace Civi\RemoteTools\Contact;
 interface RemoteContactIdResolverInterface {
 
   /**
-   * @param int|string $remoteAuthenticationToken
-   *
-   * @return int
-   *
    * @throws \Civi\RemoteTools\Exception\ResolveContactIdFailedException
    *   If a unique contact ID was not found or an error occurred.
    */
-  public function getContactId($remoteAuthenticationToken): int;
+  public function getContactId(int|string $remoteAuthenticationToken): int;
 
 }

--- a/Civi/RemoteTools/DependencyInjection/Compiler/RemoteEntityProfilePass.php
+++ b/Civi/RemoteTools/DependencyInjection/Compiler/RemoteEntityProfilePass.php
@@ -88,7 +88,7 @@ final class RemoteEntityProfilePass implements CompilerPassInterface {
     string $id,
     string $key,
     array $attributes,
-    string $default = NULL
+    ?string $default = NULL
   ): string {
     if (isset($attributes[$key])) {
       Assert::string($attributes[$key], sprintf(

--- a/Civi/RemoteTools/DependencyInjection/Compiler/Traits/DecorateServiceTrait.php
+++ b/Civi/RemoteTools/DependencyInjection/Compiler/Traits/DecorateServiceTrait.php
@@ -33,7 +33,7 @@ trait DecorateServiceTrait {
     string $id,
     string $decoratorClass,
     string $serviceIdPostfix,
-    $argumentKey = 0
+    int|string $argumentKey = 0
   ): void {
     $decoratorId = $decoratorClass . ':' . $serviceIdPostfix;
     $container->autowire($decoratorId, $decoratorClass)

--- a/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfile.php
+++ b/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfile.php
@@ -89,7 +89,7 @@ abstract class AbstractRemoteEntityProfile implements RemoteEntityProfileInterfa
   /**
    * @inheritDoc
    */
-  public function getFieldLoadOptionsForFormSpec() {
+  public function getFieldLoadOptionsForFormSpec(): bool|array {
     return FALSE;
   }
 

--- a/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfileDecorator.php
+++ b/Civi/RemoteTools/EntityProfile/AbstractRemoteEntityProfileDecorator.php
@@ -136,7 +136,7 @@ abstract class AbstractRemoteEntityProfileDecorator implements RemoteEntityProfi
   /**
    * @inheritDoc
    */
-  public function getFieldLoadOptionsForFormSpec() {
+  public function getFieldLoadOptionsForFormSpec(): bool|array {
     return $this->profile->getFieldLoadOptionsForFormSpec();
   }
 

--- a/Civi/RemoteTools/EntityProfile/EntityProfileFileDecorator.php
+++ b/Civi/RemoteTools/EntityProfile/EntityProfileFileDecorator.php
@@ -120,20 +120,16 @@ final class EntityProfileFileDecorator extends AbstractRemoteEntityProfileDecora
   }
 
   /**
-   * @param mixed $value
-   *
    * @phpstan-assert-if-true array{filename: string, content: string} $value
    */
-  private function containsNewFile($value): bool {
+  private function containsNewFile(mixed $value): bool {
     return is_array($value) && is_string($value['filename'] ?? NULL) && is_string($value['content'] ?? NULL);
   }
 
   /**
-   * @param mixed $value
-   *
    * @phpstan-assert-if-true array{filename: string, url: string} $value
    */
-  private function containsPreviousFile($value): bool {
+  private function containsPreviousFile(mixed $value): bool {
     return is_array($value) && is_string($value['filename'] ?? NULL) && is_string($value['url'] ?? NULL);
   }
 

--- a/Civi/RemoteTools/EntityProfile/EntityProfileOptionSuffixDecorator.php
+++ b/Civi/RemoteTools/EntityProfile/EntityProfileOptionSuffixDecorator.php
@@ -49,6 +49,7 @@ final class EntityProfileOptionSuffixDecorator extends AbstractRemoteEntityProfi
 
     foreach ($remoteFields as $fieldName => $field) {
       if (($field['options'] ?? FALSE) !== FALSE && is_array($field['suffixes'] ?? NULL)) {
+        /** @var string $suffix */
         foreach ($field['suffixes'] as $suffix) {
           if (
             is_array($field['options'])
@@ -136,7 +137,7 @@ final class EntityProfileOptionSuffixDecorator extends AbstractRemoteEntityProfi
    * @return bool|array
    * @phpstan-return true|array<int|string, scalar>
    */
-  private function getSuffixFieldOptions($options, string $suffix) {
+  private function getSuffixFieldOptions(bool|array $options, string $suffix): bool|array {
     if (!is_array($options)) {
       return TRUE;
     }

--- a/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityDeleter.php
+++ b/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityDeleter.php
@@ -28,10 +28,7 @@ use Civi\RemoteTools\Helper\WhereFactoryInterface;
 use Webmozart\Assert\Assert;
 
 /**
- * @phpstan-type comparisonT array{string, string, 2?: scalar|array<scalar>}
- * Actually this should be: array{string, array<int, comparisonT|compositeConditionT>},
- * so that is not possible.
- * @phpstan-type compositeConditionT array{string, array<int, array<int, mixed>>}
+ * @phpstan-import-type conditionT from \Civi\RemoteTools\Api4\Query\ConditionInterface
  */
 final class ProfileEntityDeleter implements ProfileEntityDeleterInterface {
 
@@ -98,7 +95,7 @@ final class ProfileEntityDeleter implements ProfileEntityDeleterInterface {
    * @phpstan-param array<array<string, mixed>> $entityFields
    * @phpstan-param array<array<string, mixed>> $remoteFields
    *
-   * @phpstan-return array<comparisonT|compositeConditionT>
+   * @phpstan-return list<conditionT>
    */
   private function createWhereForDelete(
     RemoteEntityProfileInterface $profile,
@@ -112,6 +109,7 @@ final class ProfileEntityDeleter implements ProfileEntityDeleterInterface {
     => $profile->convertRemoteFieldComparison($comparison, $action->getResolvedContactId());
 
     $where = $this->whereFactory->getWhere(
+      // @phpstan-ignore argument.type
       $action->getWhere(),
       $entityFields,
       $remoteFields,

--- a/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityLoader.php
+++ b/Civi/RemoteTools/EntityProfile/Helper/ProfileEntityLoader.php
@@ -30,10 +30,7 @@ use Civi\RemoteTools\Helper\SelectFactoryInterface;
 use Civi\RemoteTools\Helper\WhereFactoryInterface;
 
 /**
- * @phpstan-type comparisonT array{string, string, 2?: scalar|array<scalar>}
- * Actually this should be: array{string, array<int, comparisonT|compositeConditionT>},
- * so that is not possible.
- * @phpstan-type compositeConditionT array{string, array<int, array<int, mixed>>}
+ * @phpstan-import-type conditionT from \Civi\RemoteTools\Api4\Query\ConditionInterface
  */
 final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
 
@@ -109,7 +106,7 @@ final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
    * @phpstan-param array<array<string, mixed>> $entityFields
    * @phpstan-param array<array<string, mixed>> $remoteFields
    *
-   * @phpstan-return array{entity: array<string>, remote: array<string>, differ: bool}
+   * @phpstan-return array{entity: list<string>, remote: list<string>, differ: bool}
    *   differ is TRUE if there are extra fields in entity that are not part of
    *   remote.
    */
@@ -122,6 +119,7 @@ final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
     $implicitJoinAllowedCallback = fn(string $fieldName, string $joinField)
     => $profile->isImplicitJoinAllowed($fieldName, $joinField, $action->getResolvedContactId());
     $selects = $this->selectFactory->getSelects(
+      // @phpstan-ignore argument.type
       $action->getSelect(),
       $entityFields,
       $remoteFields,
@@ -133,6 +131,7 @@ final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
       $selects['remote'],
       $action->getResolvedContactId(),
     );
+    // @phpstan-ignore notEqual.notAllowed
     if ($selects['entity'] != $entitySelect) {
       $selects['entity'] = $entitySelect;
       $selects['differ'] = TRUE;
@@ -148,7 +147,7 @@ final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
    * @phpstan-param array<array<string, mixed>> $entityFields
    * @phpstan-param array<array<string, mixed>> $remoteFields
    *
-   * @phpstan-return array<comparisonT|compositeConditionT>
+   * @phpstan-return list<conditionT>
    */
   private function createWhereForGet(
     RemoteEntityProfileInterface $profile,
@@ -162,6 +161,7 @@ final class ProfileEntityLoader implements ProfileEntityLoaderInterface {
     => $profile->convertRemoteFieldComparison($comparison, $action->getResolvedContactId());
 
     $where = $this->whereFactory->getWhere(
+      // @phpstan-ignore argument.type
       $action->getWhere(),
       $entityFields,
       $remoteFields,

--- a/Civi/RemoteTools/EntityProfile/RemoteEntityProfileInterface.php
+++ b/Civi/RemoteTools/EntityProfile/RemoteEntityProfileInterface.php
@@ -131,15 +131,15 @@ interface RemoteEntityProfileInterface {
   public function isImplicitJoinAllowed(string $fieldName, string $joinFieldName, ?int $contactId): bool;
 
   /**
-   * @phpstan-param array<string> $select
+   * @phpstan-param list<string> $select
    *   The proposed select field names. Contains only "allowed" values on get,
    *   e.g. no implicit joins that are not allowed.
    * @phpstan-param 'delete'|'get'|'update' $actionName
-   * @phpstan-param array<string> $remoteSelect
+   * @phpstan-param list<string> $remoteSelect
    *   The field names from the remote request if action is "get", empty array
    *   otherwise.
    *
-   * @phpstan-return array<string>
+   * @phpstan-return list<string>
    *   The field names to select. In most cases just $select or $select with
    *   additional field names, e.g. if required to decide if update/delete is
    *   allowed, or if there's no 1:1 mapping between entity fields and remote
@@ -177,7 +177,7 @@ interface RemoteEntityProfileInterface {
 
   /**
    * @phpstan-param array<string, mixed> $entityValues
-   * @phpstan-param array<string> $select
+   * @phpstan-param list<string> $select
    *   Selected field names. Maybe empty on create or update.
    *
    * @phpstan-return array<string, mixed>
@@ -218,7 +218,7 @@ interface RemoteEntityProfileInterface {
   public function getUpdateFormSpec(array $entityValues, array $entityFields, ?int $contactId): FormSpec;
 
   /**
-   * @phpstan-return bool|array<string>
+   * @phpstan-return bool|list<string>
    *    Value for the 'loadOptions' parameter when fetching entity fields that
    *    are passed to the form spec creation methods. FALSE if no options are
    *    required, TRUE to get options as id-label-pairs, or an array of the
@@ -229,7 +229,7 @@ interface RemoteEntityProfileInterface {
    *
    * @api
    */
-  public function getFieldLoadOptionsForFormSpec();
+  public function getFieldLoadOptionsForFormSpec(): bool|array;
 
   /**
    * @phpstan-param array<int|string, mixed> $arguments

--- a/Civi/RemoteTools/Exception/ActionHandlerNotFoundException.php
+++ b/Civi/RemoteTools/Exception/ActionHandlerNotFoundException.php
@@ -28,7 +28,7 @@ final class ActionHandlerNotFoundException extends RuntimeException {
 
   public function __construct(
           AbstractAction $action,
-          string $message = NULL,
+          ?string $message = NULL,
           int $code = 0,
           ?\Throwable $previous = NULL
   ) {

--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormElementContainer.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormElementContainer.php
@@ -31,12 +31,12 @@ abstract class AbstractFormElementContainer {
   private string $title;
 
   /**
-   * @phpstan-var array<T>
+   * @phpstan-var list<T>
    */
   private array $elements = [];
 
   /**
-   * @phpstan-param array<T> $elements
+   * @phpstan-param list<T> $elements
    */
   public function __construct(string $title, array $elements = []) {
     $this->title = $title;
@@ -50,7 +50,7 @@ abstract class AbstractFormElementContainer {
   /**
    * @return $this
    */
-  public function setTitle(string $title): self {
+  public function setTitle(string $title): static {
     $this->title = $title;
 
     return $this;
@@ -61,14 +61,14 @@ abstract class AbstractFormElementContainer {
    *
    * @return $this
    */
-  public function addElement(FormElementInterface $element): self {
+  public function addElement(FormElementInterface $element): static {
     $this->elements[] = $element;
 
     return $this;
   }
 
   /**
-   * @phpstan-return array<T>
+   * @phpstan-return list<T>
    */
   public function getElements(): array {
     return $this->elements;
@@ -83,16 +83,16 @@ abstract class AbstractFormElementContainer {
    *
    * @return $this
    */
-  public function insertElement(FormElementInterface $element, int $index): self {
+  public function insertElement(FormElementInterface $element, int $index): static {
     array_splice($this->elements, $index, 0, [$element]);
 
     return $this;
   }
 
   /**
-   * @phpstan-param array<T> $elements
+   * @phpstan-param list<T> $elements
    */
-  public function setElements(array $elements): self {
+  public function setElements(array $elements): static {
     $this->elements = $elements;
 
     return $this;
@@ -126,7 +126,7 @@ abstract class AbstractFormElementContainer {
   }
 
   /**
-   * @phpstan-return array<string, array<SubmitButton>>
+   * @phpstan-return array<string, list<SubmitButton>>
    *   Mapping of button name to buttons with that name.
    */
   public function getSubmitButtons(): array {

--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormField.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormField.php
@@ -37,10 +37,9 @@ abstract class AbstractFormField extends AbstractFormInput {
   private bool $hasDefaultValue = FALSE;
 
   /**
-   * @var mixed
    * @phpstan-var T|null
    */
-  private $defaultValue = NULL;
+  private mixed $defaultValue = NULL;
 
   public function getType(): string {
     return 'field';
@@ -53,7 +52,7 @@ abstract class AbstractFormField extends AbstractFormInput {
   /**
    * @return $this
    */
-  public function setRequired(bool $required): self {
+  public function setRequired(bool $required): static {
     $this->required = $required;
 
     return $this;
@@ -66,7 +65,7 @@ abstract class AbstractFormField extends AbstractFormInput {
   /**
    * @return $this
    */
-  public function setReadOnly(bool $readOnly): self {
+  public function setReadOnly(bool $readOnly): static {
     $this->readOnly = $readOnly;
 
     return $this;
@@ -88,7 +87,7 @@ abstract class AbstractFormField extends AbstractFormInput {
    *
    * @see isRequired()
    */
-  public function setNullable(?bool $nullable): self {
+  public function setNullable(?bool $nullable): static {
     $this->nullable = $nullable;
 
     return $this;
@@ -105,31 +104,29 @@ abstract class AbstractFormField extends AbstractFormInput {
   /**
    * @return $this
    */
-  public function setHasDefaultValue(bool $hasDefaultValue): self {
+  public function setHasDefaultValue(bool $hasDefaultValue): static {
     $this->hasDefaultValue = $hasDefaultValue;
 
     return $this;
   }
 
   /**
-   * @return mixed
    * @phpstan-return T|null
    */
-  public function getDefaultValue() {
+  public function getDefaultValue(): mixed {
     return $this->defaultValue;
   }
 
   /**
    * Additionally sets "has default value" to TRUE.
    *
-   * @param mixed $defaultValue
    * @phpstan-param T|null $defaultValue
    *
    * @return $this
    *
    * @see hasDefaultValue()
    */
-  public function setDefaultValue($defaultValue): self {
+  public function setDefaultValue(mixed $defaultValue): static {
     $this->hasDefaultValue = TRUE;
     $this->defaultValue = $defaultValue;
 

--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormInput.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormInput.php
@@ -35,7 +35,7 @@ abstract class AbstractFormInput extends AbstractFormElement {
   /**
    * @phpstan-var limitValidationT
    */
-  private $limitValidation = NULL;
+  private null|bool|string|array $limitValidation = NULL;
 
   public function __construct(string $name, string $label) {
     $this->name = $name;
@@ -53,7 +53,7 @@ abstract class AbstractFormInput extends AbstractFormElement {
   /**
    * @return $this
    */
-  public function setName(string $name): self {
+  public function setName(string $name): static {
     $this->name = $name;
 
     return $this;
@@ -66,7 +66,7 @@ abstract class AbstractFormInput extends AbstractFormElement {
   /**
    * @return $this
    */
-  public function setLabel(string $label): self {
+  public function setLabel(string $label): static {
     $this->label = $label;
 
     return $this;
@@ -79,7 +79,7 @@ abstract class AbstractFormInput extends AbstractFormElement {
   /**
    * @return $this
    */
-  public function setDescription(string $description): self {
+  public function setDescription(string $description): static {
     $this->description = $description;
 
     return $this;
@@ -91,7 +91,7 @@ abstract class AbstractFormInput extends AbstractFormElement {
    *   to persist forms in an incomplete state. See definition of
    *   "limitValidationT" for possible values.
    */
-  public function getLimitValidation() {
+  public function getLimitValidation(): null|bool|string|array {
     return $this->limitValidation;
   }
 
@@ -105,7 +105,7 @@ abstract class AbstractFormInput extends AbstractFormElement {
    *   possible values. Might be set to false to enforce normal validation for
    *   this input if limited validation is configured in FormSpec.
    */
-  public function setLimitValidation($limitValidation): self {
+  public function setLimitValidation(null|bool|string|array $limitValidation): static {
     $this->limitValidation = $limitValidation;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Button/SubmitButton.php
+++ b/Civi/RemoteTools/Form/FormSpec/Button/SubmitButton.php
@@ -40,7 +40,7 @@ final class SubmitButton extends AbstractFormInput {
     return $this->value;
   }
 
-  public function setValue(string $value): self {
+  public function setValue(string $value): static {
     $this->value = $value;
 
     return $this;
@@ -50,7 +50,7 @@ final class SubmitButton extends AbstractFormInput {
     return $this->confirmMessage;
   }
 
-  public function setConfirmMessage(?string $confirmMessage): self {
+  public function setConfirmMessage(?string $confirmMessage): static {
     $this->confirmMessage = $confirmMessage;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/DataTransformer/HtmlDataTransformer.php
+++ b/Civi/RemoteTools/Form/FormSpec/DataTransformer/HtmlDataTransformer.php
@@ -32,11 +32,7 @@ final class HtmlDataTransformer implements FieldDataTransformerInterface {
   /**
    * @inheritDoc
    */
-  public function toEntityValue($data, AbstractFormField $field) {
-    if (!class_exists(HtmlSanitizer::class) || !class_exists(HtmlSanitizerConfig::class)) {
-      throw new \RuntimeException('symfony/html-sanitizer is required to use this class');
-    }
-
+  public function toEntityValue(mixed $data, AbstractFormField $field): mixed {
     if (!is_string($data)) {
       return NULL;
     }

--- a/Civi/RemoteTools/Form/FormSpec/Field/AbstractMultiOptionField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/AbstractMultiOptionField.php
@@ -58,9 +58,9 @@ abstract class AbstractMultiOptionField extends AbstractFormField {
   abstract public function getItemDataType(): string;
 
   /**
-   * @param T $value
+   * @phpstan-param T $value
    */
-  public function addOption($value, string $label): self {
+  public function addOption(int|string $value, string $label): static {
     $this->options[$value] = $label;
 
     return $this;
@@ -80,7 +80,7 @@ abstract class AbstractMultiOptionField extends AbstractFormField {
    *
    * @return $this
    */
-  public function setOptions(array $options): self {
+  public function setOptions(array $options): static {
     $this->options = $options;
 
     return $this;
@@ -94,7 +94,7 @@ abstract class AbstractMultiOptionField extends AbstractFormField {
     return $this->minItems;
   }
 
-  public function setMinItems(?int $minItems): self {
+  public function setMinItems(?int $minItems): static {
     $this->minItems = $minItems;
 
     return $this;
@@ -104,7 +104,7 @@ abstract class AbstractMultiOptionField extends AbstractFormField {
     return $this->maxItems;
   }
 
-  public function setMaxItems(?int $maxItems): self {
+  public function setMaxItems(?int $maxItems): static {
     $this->maxItems = $maxItems;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Field/AbstractNumberField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/AbstractNumberField.php
@@ -43,7 +43,7 @@ abstract class AbstractNumberField extends AbstractFormField {
   /**
    * @return $this
    */
-  public function setMaximum(?int $maximum): self {
+  public function setMaximum(?int $maximum): static {
     $this->maximum = $maximum;
 
     return $this;
@@ -56,7 +56,7 @@ abstract class AbstractNumberField extends AbstractFormField {
   /**
    * @return $this
    */
-  public function setMinimum(?int $minimum): self {
+  public function setMinimum(?int $minimum): static {
     $this->minimum = $minimum;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Field/AbstractOptionField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/AbstractOptionField.php
@@ -48,9 +48,9 @@ abstract class AbstractOptionField extends AbstractFormField {
   }
 
   /**
-   * @param T $value
+   * @phpstan-param T $value
    */
-  public function addOption($value, string $label): self {
+  public function addOption(int|string $value, string $label): static {
     $this->options[$value] = $label;
 
     return $this;
@@ -70,7 +70,7 @@ abstract class AbstractOptionField extends AbstractFormField {
    *
    * @return $this
    */
-  public function setOptions(array $options): self {
+  public function setOptions(array $options): static {
     $this->options = $options;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Field/AbstractTextField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/AbstractTextField.php
@@ -47,7 +47,7 @@ abstract class AbstractTextField extends AbstractFormField {
   /**
    * @return $this
    */
-  public function setMaxLength(?int $maxLength): self {
+  public function setMaxLength(?int $maxLength): static {
     $this->maxLength = $maxLength;
 
     return $this;
@@ -64,7 +64,7 @@ abstract class AbstractTextField extends AbstractFormField {
   /**
    * @return $this
    */
-  public function setMinLength(?int $minLength): self {
+  public function setMinLength(?int $minLength): static {
     $this->minLength = $minLength;
 
     return $this;
@@ -77,7 +77,7 @@ abstract class AbstractTextField extends AbstractFormField {
   /**
    * @return $this
    */
-  public function setPattern(?string $pattern): self {
+  public function setPattern(?string $pattern): static {
     $this->pattern = $pattern;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Field/FileField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/FileField.php
@@ -38,7 +38,7 @@ class FileField extends AbstractFormField {
     return $this->filename;
   }
 
-  public function setFilename(?string $filename): self {
+  public function setFilename(?string $filename): static {
     $this->filename = $filename;
 
     return $this;
@@ -62,7 +62,7 @@ class FileField extends AbstractFormField {
    *   The maximum file size in bytes. Might only be approximately if files are
    *   transferred Base64 encoded.
    */
-  public function setMaxFileSize(?int $maxFileSize): self {
+  public function setMaxFileSize(?int $maxFileSize): static {
     $this->maxFileSize = $maxFileSize;
 
     return $this;
@@ -72,7 +72,7 @@ class FileField extends AbstractFormField {
     return $this->url;
   }
 
-  public function setUrl(?string $url): self {
+  public function setUrl(?string $url): static {
     $this->url = $url;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Field/FloatField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/FloatField.php
@@ -42,7 +42,7 @@ class FloatField extends AbstractNumberField {
     return $this->precision;
   }
 
-  public function setPrecision(?int $precision): self {
+  public function setPrecision(?int $precision): static {
     $this->precision = $precision;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Field/HtmlField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/HtmlField.php
@@ -21,7 +21,6 @@ namespace Civi\RemoteTools\Form\FormSpec\Field;
 
 use Civi\RemoteTools\Form\FormSpec\DataTransformer\HtmlDataTransformer;
 use Civi\RemoteTools\Form\FormSpec\FieldDataTransformerInterface;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 
 /**
  * Input is sanitized with all non-body elements and unsafe elements being
@@ -65,9 +64,6 @@ final class HtmlField extends AbstractTextField {
   public function __construct(string $name, string $label) {
     parent::__construct($name, $label);
     $this->setMaxLength(20000);
-    if (!class_exists(HtmlSanitizer::class)) {
-      throw new \RuntimeException('symfony/html-sanitizer is required to use this class');
-    }
   }
 
   public function getInputType(): string {
@@ -82,7 +78,7 @@ final class HtmlField extends AbstractTextField {
    * @param list<string>|null $allowedAttributes
    *   If NULL, all standard attributes defined by W3C are allowed.
    */
-  public function addAllowedElement(string $element, ?array $allowedAttributes): self {
+  public function addAllowedElement(string $element, ?array $allowedAttributes): static {
     $this->allowedElements[$element] = $allowedAttributes;
     unset($this->blockedElements[$element]);
     unset($this->droppedElements[$element]);
@@ -104,7 +100,7 @@ final class HtmlField extends AbstractTextField {
    * Element that shall be removed from the input, but with its children
    * retained.
    */
-  public function addBlockedElement(string $element): self {
+  public function addBlockedElement(string $element): static {
     $this->blockedElements[$element] = TRUE;
     unset($this->allowedElements[$element]);
     unset($this->droppedElements[$element]);
@@ -122,7 +118,7 @@ final class HtmlField extends AbstractTextField {
   /**
    * Element that shall be removed from the input including its children.
    */
-  public function addDroppedElement(string $element): self {
+  public function addDroppedElement(string $element): static {
     $this->droppedElements[$element] = TRUE;
     unset($this->allowedElements[$element]);
     unset($this->blockedElements[$element]);

--- a/Civi/RemoteTools/Form/FormSpec/Field/IntegerField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/IntegerField.php
@@ -44,7 +44,7 @@ final class IntegerField extends AbstractNumberField {
     return $this->maximum;
   }
 
-  public function setMaximum(?int $maximum): self {
+  public function setMaximum(?int $maximum): static {
     $this->maximum = $maximum;
 
     return $this;
@@ -54,7 +54,7 @@ final class IntegerField extends AbstractNumberField {
     return $this->minimum;
   }
 
-  public function setMinimum(?int $minimum): self {
+  public function setMinimum(?int $minimum): static {
     $this->minimum = $minimum;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/Field/MoneyField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/MoneyField.php
@@ -45,7 +45,7 @@ final class MoneyField extends FloatField {
   /**
    * @return $this
    */
-  public function setCurrency(string $currency): self {
+  public function setCurrency(string $currency): static {
     $this->currency = $currency;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/FieldDataTransformerInterface.php
+++ b/Civi/RemoteTools/Form/FormSpec/FieldDataTransformerInterface.php
@@ -11,11 +11,8 @@ namespace Civi\RemoteTools\Form\FormSpec;
 interface FieldDataTransformerInterface {
 
   /**
-   * @param mixed $data
    * @phpstan-param T $field
-   *
-   * @return mixed
    */
-  public function toEntityValue($data, AbstractFormField $field);
+  public function toEntityValue(mixed $data, AbstractFormField $field): mixed;
 
 }

--- a/Civi/RemoteTools/Form/FormSpec/FieldValidatorInterface.php
+++ b/Civi/RemoteTools/Form/FormSpec/FieldValidatorInterface.php
@@ -11,12 +11,11 @@ namespace Civi\RemoteTools\Form\FormSpec;
 interface FieldValidatorInterface {
 
   /**
-   * @param mixed $value
    * @phpstan-param T $field
    *
    * @phpstan-return list<string>
    *   Validation error messages.
    */
-  public function validate($value, AbstractFormField $field): array;
+  public function validate(mixed $value, AbstractFormField $field): array;
 
 }

--- a/Civi/RemoteTools/Form/FormSpec/FormElementContainer.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormElementContainer.php
@@ -49,7 +49,7 @@ class FormElementContainer extends AbstractFormElementContainer implements FormE
     return $this->collapsible;
   }
 
-  public function setCollapsible(bool $collapsible): self {
+  public function setCollapsible(bool $collapsible): static {
     $this->collapsible = $collapsible;
 
     return $this;
@@ -59,7 +59,7 @@ class FormElementContainer extends AbstractFormElementContainer implements FormE
     return $this->description;
   }
 
-  public function setDescription(?string $description): self {
+  public function setDescription(?string $description): static {
     $this->description = $description;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/FormElementInterface.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormElementInterface.php
@@ -33,6 +33,6 @@ interface FormElementInterface {
   /**
    * @return $this
    */
-  public function setRule(?FormRule $rule): self;
+  public function setRule(?FormRule $rule): static;
 
 }

--- a/Civi/RemoteTools/Form/FormSpec/FormSpec.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormSpec.php
@@ -59,10 +59,10 @@ final class FormSpec extends AbstractFormElementContainer {
   /**
    * @phpstan-var limitValidationT
    */
-  private $limitValidation = NULL;
+  private null|bool|string|array $limitValidation = NULL;
 
   /**
-   * @phpstan-var array<ValidatorInterface>
+   * @phpstan-var list<ValidatorInterface>
    */
   private array $validators = [];
 
@@ -97,7 +97,7 @@ final class FormSpec extends AbstractFormElementContainer {
    *   to persist forms in an incomplete state. See definition of
    *   "limitValidationT" for possible values.
    */
-  public function getLimitValidation() {
+  public function getLimitValidation(): null|bool|string|array {
     return $this->limitValidation;
   }
 
@@ -114,7 +114,7 @@ final class FormSpec extends AbstractFormElementContainer {
    *   If "_action" is the name of the submit buttons and the submit button
    *   with the value "save" is pressed then limited validation is performed.
    */
-  public function setLimitValidation($limitValidation): self {
+  public function setLimitValidation(null|bool|string|array $limitValidation): self {
     $this->limitValidation = $limitValidation;
 
     return $this;
@@ -127,7 +127,7 @@ final class FormSpec extends AbstractFormElementContainer {
   }
 
   /**
-   * @phpstan-return array<ValidatorInterface>
+   * @phpstan-return list<ValidatorInterface>
    */
   public function getValidators(): array {
     return $this->validators;

--- a/Civi/RemoteTools/Form/FormSpec/FormTab.php
+++ b/Civi/RemoteTools/Form/FormSpec/FormTab.php
@@ -45,7 +45,7 @@ class FormTab extends AbstractFormElementContainer implements FormElementInterfa
     return $this->description;
   }
 
-  public function setDescription(?string $description): self {
+  public function setDescription(?string $description): static {
     $this->description = $description;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/IdentityFieldDataTransformer.php
+++ b/Civi/RemoteTools/Form/FormSpec/IdentityFieldDataTransformer.php
@@ -14,7 +14,7 @@ final class IdentityFieldDataTransformer implements FieldDataTransformerInterfac
   /**
    * @inheritDoc
    */
-  public function toEntityValue($data, AbstractFormField $field) {
+  public function toEntityValue(mixed $data, AbstractFormField $field): mixed {
     return $data;
   }
 

--- a/Civi/RemoteTools/Form/FormSpec/Markup/HtmlElement.php
+++ b/Civi/RemoteTools/Form/FormSpec/Markup/HtmlElement.php
@@ -45,7 +45,7 @@ final class HtmlElement extends AbstractFormElement {
    *
    * @return $this
    */
-  public function setContent(string $content): self {
+  public function setContent(string $content): static {
     $this->content = $content;
 
     return $this;

--- a/Civi/RemoteTools/Form/FormSpec/NullFieldValidator.php
+++ b/Civi/RemoteTools/Form/FormSpec/NullFieldValidator.php
@@ -17,7 +17,7 @@ final class NullFieldValidator implements FieldValidatorInterface {
   /**
    * @inheritDoc
    */
-  public function validate($value, AbstractFormField $field): array {
+  public function validate(mixed $value, AbstractFormField $field): array {
     return [];
   }
 

--- a/Civi/RemoteTools/Form/FormSpec/Rule/FormRuleTrait.php
+++ b/Civi/RemoteTools/Form/FormSpec/Rule/FormRuleTrait.php
@@ -19,8 +19,6 @@ declare(strict_types = 1);
 
 namespace Civi\RemoteTools\Form\FormSpec\Rule;
 
-use Civi\RemoteTools\Form\FormSpec\FormElementInterface;
-
 trait FormRuleTrait {
 
   private ?FormRule $rule = NULL;
@@ -29,7 +27,7 @@ trait FormRuleTrait {
     return $this->rule;
   }
 
-  public function setRule(?FormRule $rule): FormElementInterface {
+  public function setRule(?FormRule $rule): static {
     $this->rule = $rule;
 
     return $this;

--- a/Civi/RemoteTools/Form/Validation/ValidationResult.php
+++ b/Civi/RemoteTools/Form/Validation/ValidationResult.php
@@ -25,7 +25,7 @@ use CRM_Remotetools_ExtensionUtil as E;
 class ValidationResult {
 
   /**
-   * @phpstan-var array<string, non-empty-array<ValidationError>>
+   * @phpstan-var array<string, non-empty-list<ValidationError>>
    */
   private array $errors = [];
 
@@ -37,7 +37,7 @@ class ValidationResult {
     $this->addErrors(...$errors);
   }
 
-  public function addErrors(ValidationError ...$errors): self {
+  public function addErrors(ValidationError ...$errors): static {
     foreach ($errors as $error) {
       $this->addError($error);
     }
@@ -45,7 +45,7 @@ class ValidationResult {
     return $this;
   }
 
-  public function addError(ValidationError $error): self {
+  public function addError(ValidationError $error): static {
     if (isset($this->errors[$error->field])) {
       $this->errors[$error->field][] = $error;
     }
@@ -57,7 +57,7 @@ class ValidationResult {
   }
 
   /**
-   * @phpstan-return array<string, non-empty-array<ValidationError>>
+   * @phpstan-return array<string, non-empty-list<ValidationError>>
    *   Field names mapped to errors.
    */
   public function getErrors(): array {
@@ -65,7 +65,7 @@ class ValidationResult {
   }
 
   /**
-   * @phpstan-return array<ValidationError>
+   * @phpstan-return list<ValidationError>
    */
   public function getErrorsFlat(): array {
     $errors = [];
@@ -83,7 +83,7 @@ class ValidationResult {
   }
 
   /**
-   * @phpstan-return array<string, non-empty-array<string>>
+   * @phpstan-return array<string, non-empty-list<string>>
    *   Field names mapped to error messages.
    */
   public function getErrorMessages(): array {
@@ -97,7 +97,7 @@ class ValidationResult {
   }
 
   /**
-   * @phpstan-return array<ValidationError>
+   * @phpstan-return list<ValidationError>
    */
   public function getErrorsFor(string $field): array {
     return $this->errors[$field] ?? [];
@@ -111,7 +111,7 @@ class ValidationResult {
     return [] === $this->errors;
   }
 
-  public function merge(self $result): self {
+  public function merge(self $result): static {
     $this->addErrors(...$result->getErrorsFlat());
 
     return $this;

--- a/Civi/RemoteTools/Helper/FilePersister.php
+++ b/Civi/RemoteTools/Helper/FilePersister.php
@@ -47,7 +47,10 @@ final class FilePersister implements FilePersisterInterface {
 
   public function persistFile(string $filename, string $content, ?string $description, ?int $contactId): int {
     $safeFilename = \CRM_Utils_File::makeFileName($filename, TRUE);
-    $filePath = $this->config->customFileUploadDir . $safeFilename;
+    /** @var string $customFileUploadDir */
+    // Since CiviCRM 6.1 this property is type hinted, so this can be reduced to a single line sometime in the future.
+    $customFileUploadDir = $this->config->customFileUploadDir;
+    $filePath = $customFileUploadDir . $safeFilename;
 
     $this->transactionManager->getBaseFrame()->addCallback(
       \CRM_Core_Transaction::PHASE_PRE_ROLLBACK,

--- a/Civi/RemoteTools/Helper/SelectFactoryInterface.php
+++ b/Civi/RemoteTools/Helper/SelectFactoryInterface.php
@@ -22,12 +22,12 @@ namespace Civi\RemoteTools\Helper;
 interface SelectFactoryInterface {
 
   /**
-   * @phpstan-param array<string> $select
+   * @phpstan-param list<string> $select
    * @phpstan-param array<string, array<string, mixed>> $entityFields
    * @phpstan-param array<string, array<string, mixed>> $remoteFields
    * @phpstan-param callable(string $fieldName, string $joinedFieldName): bool $implicitJoinAllowedCallback
    *
-   * @phpstan-return array{entity: array<string>, remote: array<string>}
+   * @phpstan-return array{entity: list<string>, remote: list<string>}
    */
   public function getSelects(
     array $select,

--- a/Civi/RemoteTools/Helper/WhereFactoryInterface.php
+++ b/Civi/RemoteTools/Helper/WhereFactoryInterface.php
@@ -20,23 +20,20 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\Helper;
 
 /**
- * @phpstan-type comparisonT array{string, string, 2?: scalar|array<scalar>}
- * Actually this should be: array{string, array<int, comparisonT|compositeConditionT>},
- * so that is not possible.
- * @phpstan-type compositeConditionT array{string, array<int, array<int, mixed>>}
+ * @phpstan-import-type conditionT from \Civi\RemoteTools\Api4\Query\ConditionInterface
  */
 interface WhereFactoryInterface {
 
   /**
    * phpcs:disable Generic.Files.LineLength.TooLong
    *
-   * @phpstan-param array<comparisonT|compositeConditionT> $where
+   * @phpstan-param list<conditionT> $where
    * @phpstan-param array<string, array<string, mixed>> $entityFields
    * @phpstan-param array<string, array<string, mixed>> $remoteFields
    * @phpstan-param callable(string $fieldName, string $joinedFieldName): bool $implicitJoinAllowedCallback
    * @phpstan-param callable(\Civi\RemoteTools\Api4\Query\Comparison $comparison): ?\Civi\RemoteTools\Api4\Query\ConditionInterface $convertRemoteFieldComparisonCallback
    *
-   * @phpstan-return array<comparisonT|compositeConditionT>
+   * @phpstan-return list<conditionT>
    *
    * phpcs:enable
    * }

--- a/Civi/RemoteTools/JsonForms/Control/JsonFormsArray.php
+++ b/Civi/RemoteTools/JsonForms/Control/JsonFormsArray.php
@@ -24,7 +24,7 @@ use Civi\RemoteTools\JsonForms\JsonFormsControl;
 class JsonFormsArray extends JsonFormsControl {
 
   /**
-   * @phpstan-param array<int, JsonFormsControl>|null $elements
+   * @phpstan-param list<JsonFormsControl>|null $elements
    *   The elements of each array entry to display. If NULL, all elements are
    *   shown based on the JSON schema.
    * @phpstan-param array{

--- a/Civi/RemoteTools/JsonForms/JsonFormsControl.php
+++ b/Civi/RemoteTools/JsonForms/JsonFormsControl.php
@@ -57,9 +57,9 @@ class JsonFormsControl extends JsonFormsElement {
     return $this->keywords['options']->keywords['readonly'] ?? NULL;
   }
 
-  public function setReadonly(bool $readonly): self {
+  public function setReadonly(bool $readonly): static {
     /** @var \Civi\RemoteTools\JsonSchema\JsonSchema $options */
-    // @phpstan-ignore-next-line
+    // @phpstan-ignore voku.Coalesce
     $options = $this->keywords['options'] ??= new JsonSchema([]);
     $options->addKeyword('readonly', $readonly);
 

--- a/Civi/RemoteTools/JsonForms/JsonFormsLayout.php
+++ b/Civi/RemoteTools/JsonForms/JsonFormsLayout.php
@@ -24,7 +24,7 @@ use Civi\RemoteTools\JsonSchema\JsonSchema;
 class JsonFormsLayout extends JsonFormsElement {
 
   /**
-   * @param array<int, JsonFormsElement> $elements
+   * @param list<JsonFormsElement> $elements
    * @param array<string, mixed>|null $options
    */
   public function __construct(
@@ -51,10 +51,10 @@ class JsonFormsLayout extends JsonFormsElement {
   }
 
   /**
-   * @return array<int, JsonFormsElement>
+   * @return list<JsonFormsElement>
    */
   public function getElements(): array {
-    /** @var array<int, JsonFormsElement> $elements */
+    /** @var list<JsonFormsElement> $elements */
     $elements = $this->keywords['elements'];
 
     return $elements;
@@ -65,7 +65,7 @@ class JsonFormsLayout extends JsonFormsElement {
     return $this->keywords['options']->keywords['readonly'] ?? NULL;
   }
 
-  public function setReadonly(bool $readonly): self {
+  public function setReadonly(bool $readonly): static {
     /** @var \Civi\RemoteTools\JsonSchema\JsonSchema $options */
     // @phpstan-ignore-next-line
     $options = $this->keywords['options'] ??= new JsonSchema([]);

--- a/Civi/RemoteTools/JsonForms/Util/JsonFormsUtil.php
+++ b/Civi/RemoteTools/JsonForms/Util/JsonFormsUtil.php
@@ -22,7 +22,7 @@ namespace Civi\RemoteTools\JsonForms\Util;
 final class JsonFormsUtil {
 
   /**
-   * @phpstan-param array<string> $path
+   * @phpstan-param list<string> $path
    */
   public static function pathToScope(array $path): string {
     return '#/properties/' . implode('/properties/', $path);

--- a/Civi/RemoteTools/JsonSchema/FormSpec/LimitValidationSchemaFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/LimitValidationSchemaFactory.php
@@ -15,7 +15,7 @@ final class LimitValidationSchemaFactory {
   /**
    * @phpstan-param limitValidationT $limitValidation
    */
-  public static function createSchema($limitValidation): ?JsonSchema {
+  public static function createSchema(null|bool|string|array $limitValidation): ?JsonSchema {
     $condition = self::createCondition($limitValidation);
 
     if (NULL === $condition) {
@@ -135,10 +135,8 @@ final class LimitValidationSchemaFactory {
 
   /**
    * @phpstan-param limitValidationT $limitValidation
-   *
-   * @return bool|null|JsonSchema
    */
-  private static function createCondition($limitValidation) {
+  private static function createCondition(null|bool|string|array $limitValidation): bool|null|JsonSchema {
     if (NULL === $limitValidation) {
       return NULL;
     }

--- a/Civi/RemoteTools/JsonSchema/JsonSchema.php
+++ b/Civi/RemoteTools/JsonSchema/JsonSchema.php
@@ -86,11 +86,9 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
   }
 
   /**
-   * @param mixed $value
-   *
    * @phpstan-assert TValue $value
    */
-  protected static function assertAllowedValue($value): void {
+  protected static function assertAllowedValue(mixed $value): void {
     if (!static::isAllowedValue($value)) {
       throw new \InvalidArgumentException(
         \sprintf(
@@ -104,11 +102,9 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
   }
 
   /**
-   * @param mixed $value
-   *
    * @phpstan-assert-if-true TValue $value
    */
-  protected static function isAllowedValue($value): bool {
+  protected static function isAllowedValue(mixed $value): bool {
     if (!\is_array($value)) {
       $value = [$value];
     }
@@ -153,12 +149,11 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
   }
 
   /**
-   * @param string $keyword
-   * @param TValue $value
+   * @phpstan-param TValue $value
    *
    * @return $this
    */
-  public function addKeyword(string $keyword, $value): self {
+  public function addKeyword(string $keyword, bool|float|int|string|self|null|array $value): static {
     if ($this->hasKeyword($keyword)) {
       throw new \InvalidArgumentException(\sprintf('Keyword "%s" already exists', $keyword));
     }
@@ -186,7 +181,7 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
    *
    * @return TValue
    */
-  public function getKeywordValue(string $keyword) {
+  public function getKeywordValue(string $keyword): bool|float|int|string|self|null|array {
     if (!$this->hasKeyword($keyword)) {
       throw new \InvalidArgumentException(\sprintf('No such keyword "%s"', $keyword));
     }
@@ -194,21 +189,16 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
     return $this->keywords[$keyword];
   }
 
-  /**
-   * @param mixed $default
-   *
-   * @return mixed
-   */
-  public function getKeywordValueOrDefault(string $keyword, $default) {
+  public function getKeywordValueOrDefault(string $keyword, mixed $default): mixed {
     return $this->hasKeyword($keyword) ? $this->keywords[$keyword] : $default;
   }
 
   /**
-   * @phpstan-param string|array<string> $path
+   * @phpstan-param string|list<string> $path
    *
    * @return TValue
    */
-  public function getKeywordValueAt($path) {
+  public function getKeywordValueAt(string|array $path): bool|float|int|string|self|null|array {
     if (is_string($path)) {
       $path = explode('/', ltrim($path, '/'));
     }
@@ -229,12 +219,9 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
   }
 
   /**
-   * @phpstan-param string|array<string> $path
-   * @param mixed $default
-   *
-   * @return mixed
+   * @phpstan-param string|list<string> $path
    */
-  public function getKeywordValueAtOrDefault($path, $default) {
+  public function getKeywordValueAtOrDefault(string|array $path, mixed $default): mixed {
     if (is_string($path)) {
       $path = explode('/', ltrim($path, '/'));
     }
@@ -301,23 +288,23 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
   /**
    * @inheritDoc
    */
-  #[\ReturnTypeWillChange]
-  public function jsonSerialize() {
+  public function jsonSerialize(): \stdClass {
     return (object) $this->toArray();
   }
 
   /**
    * @inheritDoc
    */
-  public function offsetExists($keyword): bool {
+  public function offsetExists(mixed $keyword): bool {
     return $this->hasKeyword($keyword);
   }
 
   /**
    * @inheritDoc
+   *
+   * @phpstan-return TValue
    */
-  #[\ReturnTypeWillChange]
-  public function offsetGet($keyword) {
+  public function offsetGet(mixed $keyword): bool|float|int|string|self|null|array {
     return $this->keywords[$keyword] ?? NULL;
   }
 
@@ -328,7 +315,7 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
    *   Array values can be scalars, NULL, or JsonSchema objects, and arrays
    *   containing values of these three types.
    */
-  public function offsetSet($keyword, $value): void {
+  public function offsetSet(mixed $keyword, mixed $value): void {
     if (!is_string($keyword)) {
       throw new \InvalidArgumentException(sprintf('Offset must be of type string, got %s', gettype($keyword)));
     }
@@ -351,7 +338,7 @@ class JsonSchema implements \ArrayAccess, \IteratorAggregate, \JsonSerializable 
   /**
    * @inheritDoc
    */
-  public function offsetUnset($keyword): void {
+  public function offsetUnset(mixed $keyword): void {
     unset($this->keywords[$keyword]);
   }
 

--- a/Civi/RemoteTools/JsonSchema/JsonSchemaDataPointer.php
+++ b/Civi/RemoteTools/JsonSchema/JsonSchemaDataPointer.php
@@ -33,7 +33,7 @@ class JsonSchemaDataPointer extends JsonSchema {
    * @phpstan-param TValue $fallback
    *   Fallback is used if the pointed element does not exist or has no value.
    */
-  public function __construct(string $path, $fallback = NULL) {
+  public function __construct(string $path, bool|float|int|string|JsonSchema|null|array $fallback = NULL) {
     $keywords = ['$data' => $path];
     if (NULL !== $fallback) {
       $keywords['fallback'] = $fallback;

--- a/Civi/RemoteTools/JsonSchema/Util/JsonSchemaUtil.php
+++ b/Civi/RemoteTools/JsonSchema/Util/JsonSchemaUtil.php
@@ -29,7 +29,7 @@ final class JsonSchemaUtil {
    * @phpstan-param non-empty-array<int|string, string> $titles
    *   Allowed values mapped to titles.
    *
-   * @phpstan-return non-empty-array<JsonSchema>
+   * @phpstan-return non-empty-list<JsonSchema>
    *   To be used as value of "oneOf" keyword.
    *
    * @see buildTitledOneOf2()
@@ -50,7 +50,7 @@ final class JsonSchemaUtil {
    * @phpstan-param non-empty-array<string, scalar|null> $values
    *   Titles mapped to values. Every value should only appear once.
    *
-   * @phpstan-return non-empty-array<JsonSchema>
+   * @phpstan-return non-empty-list<JsonSchema>
    *   To be used as value of "oneOf" keyword.
    *
    * @see buildTitledOneOf()
@@ -65,7 +65,7 @@ final class JsonSchemaUtil {
   }
 
   /**
-   * @phpstan-param array<int|string> $path
+   * @phpstan-param list<int|string> $path
    */
   public static function getPropertySchemaAt(JsonSchema $jsonSchema, array $path): ?JsonSchema {
     foreach ($path as $pathElement) {

--- a/Civi/RemoteTools/JsonSchema/Validation/ValidationResult.php
+++ b/Civi/RemoteTools/JsonSchema/Validation/ValidationResult.php
@@ -70,6 +70,7 @@ final class ValidationResult implements ValidationResultInterface {
    * @return array<string, non-empty-list<string>>
    */
   public function getErrorMessages(): array {
+    // @phpstan-ignore argument.type
     return $this->mapErrorsToMessages($this->errorCollector->getErrors());
   }
 
@@ -77,6 +78,7 @@ final class ValidationResult implements ValidationResultInterface {
    * @return array<string, non-empty-list<string>>
    */
   public function getLeafErrorMessages(): array {
+    // @phpstan-ignore argument.type
     return $this->mapErrorsToMessages($this->errorCollector->getLeafErrors());
   }
 

--- a/Civi/RemoteTools/RequestContext/RequestContext.php
+++ b/Civi/RemoteTools/RequestContext/RequestContext.php
@@ -31,14 +31,14 @@ final class RequestContext implements RequestContextInterface {
   /**
    * @inheritDoc
    */
-  public function get(string $key, $default = NULL) {
+  public function get(string $key, mixed $default = NULL): mixed {
     return $this->data[$key] ?? $default;
   }
 
   /**
    * @inheritDoc
    */
-  public function set(string $key, $value): void {
+  public function set(string $key, mixed $value): void {
     $this->data[$key] = $value;
   }
 

--- a/Civi/RemoteTools/RequestContext/RequestContextInterface.php
+++ b/Civi/RemoteTools/RequestContext/RequestContextInterface.php
@@ -24,17 +24,9 @@ namespace Civi\RemoteTools\RequestContext;
  */
 interface RequestContextInterface {
 
-  /**
-   * @param mixed $default
-   *
-   * @return mixed
-   */
-  public function get(string $key, $default = NULL);
+  public function get(string $key, mixed $default = NULL): mixed;
 
-  /**
-   * @param mixed $value
-   */
-  public function set(string $key, $value): void;
+  public function set(string $key, mixed $value): void;
 
   /**
    * @return int

--- a/Civi/RemoteTools/Util/JsonConverter.php
+++ b/Civi/RemoteTools/Util/JsonConverter.php
@@ -31,6 +31,7 @@ final class JsonConverter {
   public static function toArray(\stdClass $data): array {
     $result = \json_decode(\json_encode($data, JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION), TRUE);
     Assert::isArray($result);
+    /** @var array<string, mixed> $result */
 
     return $result;
   }

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ could be your website, and/or another database.
 
 ## Requirements
 
-* PHP 7.4 or 8
-* CiviCRM 5.57
+* PHP 8.1+
+* CiviCRM 5.57+
 
 ## Installation
 
@@ -25,6 +25,7 @@ could be your website, and/or another database.
   * [de.systopia.xcm](https://github.com/systopia/de.systopia.xcm)
 * Add the extension folder to your CiviCRM `ext` directory.
 * If your project uses composer: Add the requirements listed in `composer.json` to your composer project:
+  * [symfony/html-sanitizer](https://github.com/symfony/html-sanitizer)
   * [systopia/expression-language-ext](https://github.com/systopia/expression-language-ext)
   * [systopia/opis-json-schema-ext](https://github.com/systopia/opis-json-schema-ext)
   * [webmozart/assert](https://github.com/webmozarts/assert)
@@ -102,7 +103,7 @@ Drupal forms.
 Custom forms for contact searches can be inherited from class [CRM_Remotetools_RemoteContactProfile](CRM/Remotetools/RemoteContactProfile.php).
 Your profile class needs to implement the following methods:
 
-* `getProfileID()` 
+* `getProfileID()`
   * return the profile id, ie. `'my-profile'`
 * `getProfileName()`
   * return the human readable form of the profile id, .ie `'This is my profile'`
@@ -122,7 +123,7 @@ In addition, take a look and implement the following methods:
 * `filterResult()`
   * apply customization to the result of a search query
 * `isOwnDataProfile`
-  * see method comments and either return `true` or `false` 
+  * see method comments and either return `true` or `false`
 
 ##### Field specification
 
@@ -133,7 +134,7 @@ passed on to `setFieldSpec()` in `addFields()`:
 
 ```php
 $fields_collection->setFieldSpec(
-  'a_list', 
+  'a_list',
   [
     'name' => 'a_list'
     'type' => CRM_Utils_Type::T_ENUM,

--- a/ci/composer.json
+++ b/ci/composer.json
@@ -10,6 +10,6 @@
         "sort-packages": true
     },
     "require": {
-        "civicrm/civicrm-core": "^5.57"
+        "civicrm/civicrm-core": ">=5.57"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "systopia/de.systopia.remotetools",
+    "description": "Toolbox to integrate CiviCRM with remote systems",
     "type": "civicrm-ext",
     "license": "AGPL-3.0-or-later",
     "authors": [
@@ -18,6 +19,8 @@
         }
     },
     "require": {
+        "php": "^8.1",
+        "symfony/html-sanitizer": ">=6",
         "symfony/mime": ">=4.4",
         "systopia/expression-language-ext": "~0.1",
         "systopia/opis-json-schema-ext": "~0.4",
@@ -59,9 +62,6 @@
     "require-dev": {
         "psr/simple-cache": "^1 || ^2 || ^3",
         "symfony/event-dispatcher-contracts": "^1 || ^2 || ^3"
-    },
-    "suggest": {
-        "symfony/html-sanitizer": "Required for HTML input field in remote forms"
     },
     "extra": {
         "branch-alias": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,6 +24,10 @@ parameters:
 	universalObjectCratesClasses:
 		- Civi\Core\Event\GenericHookEvent
 		- CRM_Core_Config
+		- CRM_Core_DAO
+	earlyTerminatingMethodCalls:
+		CRM_Queue_Runner:
+		  - runAllViaWeb
 	checkTooWideReturnTypesInProtectedAndPublicMethods: true
 	checkUninitializedProperties: true
 	checkMissingCallableSignature: true
@@ -40,6 +44,9 @@ parameters:
 		# https://youtrack.jetbrains.com/issue/WI-63891/PHPStan-ignoreErrors-configuration-isnt-working-with-inspections
 		-
 			identifier: missingType.generics
+		-
+			path: */Civi/RemoteTools/Api4/Action/Traits/*
+			identifier: trait.unused
 
 		- '#^Method Civi\\RemoteTools\\Api4\\Action\\[^\s]+Action::getHandlerResult\(\) has Civi\\RemoteTools\\Exception\\ActionHandlerNotFoundException in PHPDoc @throws tag but it.s not thrown.$#'
 		- '#^Method Civi\\RemoteTools\\Api4\\Api4::createAction\(\) should return Civi\\Api4\\Generic\\AbstractAction but returns array|Civi\Api4\Generic\AbstractAction.$#'

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   civicrm:
-    image: michaelmcandrew/civicrm:${CIVICRM_IMAGE_TAG:-5-drupal}
+    image: michaelmcandrew/civicrm:${CIVICRM_IMAGE_TAG:-drupal}
     environment:
       - PROJECT_NAME=test
       - BASE_URL=http://localhost
@@ -9,6 +9,8 @@ services:
       - CIVICRM_DB_PASS=secret
       - CIVICRM_DB_HOST=mysql
       - CIVICRM_DB_PORT=3306
+      - CIVICRM_CRED_KEYS=aes-cbc::test
+      - CIVICRM_SIGN_KEYS=jwt-hs256::test
       - CIVICRM_SITE_KEY=TEST_KEY
       - DRUPAL_DB_NAME=test
       - DRUPAL_DB_USER=root

--- a/tests/docker-phpunit.sh
+++ b/tests/docker-phpunit.sh
@@ -12,7 +12,6 @@ fi
 # CIVICRM_SMARTY_AUTOLOAD_PATH is not set in the container's civicrm.settings.php so we have to do it here.
 # Otherwise this results in this error:
 # Fatal error: Cannot declare class Smarty, because the name is already in use in /var/www/html/sites/all/modules/civicrm/packages/smarty5/Smarty.php on line 4
-#
 smarty=$(printf '%s\n' /var/www/html/sites/all/modules/civicrm/packages/smarty* | sort -r | head -n1)
 if [ -e "$smarty/Smarty.php" ]; then
   export CIVICRM_SMARTY_AUTOLOAD_PATH="$smarty/Smarty.php"

--- a/tests/docker-prepare.sh
+++ b/tests/docker-prepare.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 set -eu -o pipefail
 
-XCM_VERSION=1.13.1
+XCM_VERSION=1.14.0
 IDENTITYTRACKER_VERSION=1.4.0
 
 EXT_DIR=$(dirname "$(dirname "$(realpath "$0")")")
 EXT_NAME=$(basename "$EXT_DIR")
+
+if ! type git >/dev/null 2>&1; then
+  apt -y update
+  apt -y install git
+fi
+
+# Prevent this git error: The repository does not have the correct ownership and git refuses to use it
+git config --global --add safe.directory "/var/www/html/sites/default/files/civicrm/ext/$EXT_NAME"
 
 i=0
 while ! mysql -h "$CIVICRM_DB_HOST" -P "$CIVICRM_DB_PORT" -u "$CIVICRM_DB_USER" --password="$CIVICRM_DB_PASS" -e 'SELECT 1;' >/dev/null 2>&1; do
@@ -30,21 +38,30 @@ else
     -i /var/www/html/sites/default/civicrm.settings.php
   civicrm-docker-install
 
-  cv ext:download "de.systopia.xcm@https://github.com/systopia/de.systopia.xcm/releases/download/$XCM_VERSION/de.systopia.xcm-$XCM_VERSION.zip"
-  cv ext:download "de.systopia.identitytracker@https://github.com/systopia/de.systopia.identitytracker/archive/refs/tags/$IDENTITYTRACKER_VERSION.zip"
-  cv ext:enable "$EXT_NAME"
+  # Avoid this error:
+  # The autoloader expected class "Civi\ActionSchedule\Mapping" to be defined in
+  # file "[...]/Civi/ActionSchedule/Mapping.php". The file was found but the
+  # class was not in it, the class name or namespace probably has a typo.
+  #
+  # Necessary for CiviCRM 5.66.0 - 5.74.x.
+  # https://github.com/civicrm/civicrm-core/blob/5.66.0/Civi/ActionSchedule/Mapping.php
+  if [ -e /var/www/html/sites/all/modules/civicrm/Civi/ActionSchedule/Mapping.php ] \
+      && grep -q '// Empty file' /var/www/html/sites/all/modules/civicrm/Civi/ActionSchedule/Mapping.php; then
+    rm /var/www/html/sites/all/modules/civicrm/Civi/ActionSchedule/Mapping.php
+  fi
 
   # For headless tests these files need to exist.
   touch /var/www/html/sites/all/modules/civicrm/sql/test_data.mysql
   touch /var/www/html/sites/all/modules/civicrm/sql/test_data_second_domain.mysql
+
+  cv ext:download "de.systopia.xcm@https://github.com/systopia/de.systopia.xcm/releases/download/$XCM_VERSION/de.systopia.xcm-$XCM_VERSION.zip"
+  cv ext:download "de.systopia.identitytracker@https://github.com/systopia/de.systopia.identitytracker/archive/refs/tags/$IDENTITYTRACKER_VERSION.zip"
+  cv ext:enable "$EXT_NAME"
 fi
 
 cd "$EXT_DIR"
 # In the container used for tests there seems to be psr/cache 1 installed somewhere.
 # This conflicts with symfony/cache >=6, thus we use version 5 here.
 composer require --no-update 'symfony/cache:^5'
-# symfony/html-sanitizer requires PHP >=8.1. So installation will fail if we test with an earlier version.
-# Affected tests are skipped in that case.
-composer require --no-update symfony/html-sanitizer ||:
 composer update --no-progress --prefer-dist --optimize-autoloader --no-dev
 composer composer-phpunit -- update --no-progress --prefer-dist

--- a/tests/phpunit/Civi/Api4/RemoteEntityTest.php
+++ b/tests/phpunit/Civi/Api4/RemoteEntityTest.php
@@ -268,6 +268,7 @@ final class RemoteEntityTest extends AbstractRemoteToolsHeadlessTestCase {
     // @phpstan-ignore offsetAccess.nonOffsetAccessible
     static::assertIsArray($result['errors']['']);
     static::assertCount(1, $result['errors']['']);
+    static::assertIsString($result['errors'][''][0]);
     static::assertStringContainsString('title', $result['errors'][''][0]);
 
     $result = TestRemoteGroup::validateCreateForm()
@@ -280,6 +281,7 @@ final class RemoteEntityTest extends AbstractRemoteToolsHeadlessTestCase {
     // @phpstan-ignore offsetAccess.nonOffsetAccessible
     static::assertIsArray($result['errors']['']);
     static::assertCount(1, $result['errors']['']);
+    static::assertIsString($result['errors'][''][0]);
     static::assertStringContainsString('foo', $result['errors'][''][0]);
 
     $result = TestRemoteGroup::validateCreateForm()

--- a/tests/phpunit/Civi/RemoteTools/Form/FormSpec/DataTransformer/HtmlDataTransformerTest.php
+++ b/tests/phpunit/Civi/RemoteTools/Form/FormSpec/DataTransformer/HtmlDataTransformerTest.php
@@ -21,20 +21,11 @@ namespace Civi\RemoteTools\Form\FormSpec\DataTransformer;
 
 use Civi\RemoteTools\Form\FormSpec\Field\HtmlField;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 
 /**
  * @covers \Civi\RemoteTools\Form\FormSpec\DataTransformer\HtmlDataTransformer
  */
 final class HtmlDataTransformerTest extends TestCase {
-
-  protected function setUp(): void {
-    if (!class_exists(HtmlSanitizer::class)) {
-      static::markTestSkipped('symfony/html-sanitizer is not installed.');
-    }
-
-    parent::setUp();
-  }
 
   public function testToEntityValue(): void {
     $transformer = new HtmlDataTransformer();

--- a/tools/create-release.sh
+++ b/tools/create-release.sh
@@ -1,0 +1,399 @@
+#!/bin/bash
+set -euo pipefail
+
+# shellcheck disable=SC2155
+readonly PHP=$(which "${PHP:-php}")
+# shellcheck disable=SC2155
+readonly COMPOSER=$(which "${COMPOSER:-composer}")
+# shellcheck disable=SC2155
+readonly JQ=$(which "${JQ:-jq}")
+
+if [ -z "$PHP" ]; then
+  echo "php not found" >&2
+  exit 1
+fi
+
+if [ -z "$COMPOSER" ]; then
+  echo "composer not found" >&2
+  exit 1
+fi
+
+if [ -z "$JQ" ]; then
+  echo "jq not found" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC2155
+readonly SCRIPT_NAME=$(basename "$0")
+
+usage() {
+  cat <<EOD
+Usage: $SCRIPT_NAME [-h|--help] [--dry-run] [--no-composer] [--no-pot-update] [version] [develStage] [nextVersion]
+
+Arguments:
+  version  Version of the release (e.g. 1.2.3 or 1.2.3-alpha1)
+    Default: The version in info.xml without "-dev".
+  develStage  Development stage (dev, alpha, beta, stable).
+    Default: Detected from version.
+  nextVersion  Version after the release.
+    Default: Increased version with "dev" as pre-release part.
+
+All values that are determined programmatically have to be confirmed.
+
+Options:
+  --no-composer  Do not add composer dependencies.
+  --no-pot-update  Do not update .pot file.
+  --dry-run  Do nothing, just print what would be done.
+  -h|--help  Show this help.
+
+Help:
+  This script can be used when creating a new CiviCRM extension release. It will
+  update the info.xml, add composer dependencies (if any), make a git commit and
+  a git tag for the release. Then the info.xml is updated again using
+  nextVersion, composer dependencies are removed, branch alias in composer.json
+  gets updated if on main/master branch, and the changes are commited. The
+  changes have to be pushed manually.
+
+  Before this is done, the .pot file will be updated if existent. If it differs
+  from the currently commited one, no further changes will be made and you must
+  first update the translation and push the changes to the repository. This can
+  be disabled with the option --no-pot-update if necessary.
+
+  The script has to be executed in the directory of the extension to release.
+EOD
+}
+
+run() {
+  echo "$@"
+  [ $DRY_RUN -eq 1 ] || "$@"
+}
+
+composer() {
+  "$PHP" "$COMPOSER" "$@"
+}
+
+detectVersion() {
+  local -r version=$(grep '<version>.*</version>' info.xml | sed 's#[[:space:]]*<version>\(.*\)</version>[[:space:]]*#\1#')
+  if [ -z "$version" ]; then
+    echo "Version not found in info.xml" >&2
+    exit 1
+  fi
+
+  if ! [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-dev$ ]]; then
+    echo "The version number $version doesn't match the form a.b.c-dev" >&2
+    exit 1
+  fi
+
+  echo "${BASH_REMATCH[1]}"
+}
+
+detectDevelStage() {
+  local -r version=$1
+  if [[ "$version" = *alpha* ]]; then
+    echo alpha
+  elif [[ "$version" = *beta* ]]; then
+    echo beta
+  elif [[ "$version" = 0.* ]]; then
+    echo dev
+  else
+    echo stable
+  fi
+}
+
+detectNextVersion() {
+  local -r version=$1
+  [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]
+
+  local -r major=${BASH_REMATCH[1]}
+  local minor=${BASH_REMATCH[2]}
+  local patch=${BASH_REMATCH[3]}
+
+  if [[ "$version" = *-* ]]; then
+    # $version has pre-release
+    true
+  elif [ "$major" = 0 ]; then
+    patch=$((patch+1))
+  elif [ "$patch" = 0 ]; then
+    minor=$((minor+1))
+  else
+    patch=$((patch+1))
+  fi
+
+  echo "$major.$minor.$patch-dev"
+}
+
+validateVersion() {
+  local -r version=$1
+  if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)[1-9][0-9]*)?$ ]]; then
+    echo "The version number $version is not a valid release version" >&2
+    exit 1
+  fi
+
+  if [ -n "$(git tag -l "$version")" ]; then
+    echo "git tag $version already exists" >&2
+    exit 1
+  fi
+}
+
+validateDevelopmentStage() {
+  local -r develStage=$1
+  if ! [[ "$develStage" =~ ^(stable|alpha|beta|dev)$ ]]; then
+    echo "$develStage is not a valid development stage" >&2
+    exit 1
+  fi
+}
+
+validateNextVersion() {
+  local -r nextVersion=$1
+  if ! [[ "$nextVersion" =~ ^[0-9]+\.[0-9]+\.[0-9]+-dev$ ]]; then
+    echo "The version number $nextVersion is not a valid next version" >&2
+    exit 1
+  fi
+}
+
+validateInfoXml() {
+  if [ ! -f info.xml ]; then
+    echo "info.xml not found in working directory" >&2
+    exit 1
+  fi
+
+  # Ensure info.xml contains elements so that they can be replaced in updateInfoXml.
+  if ! grep -q "<version>.*</version>" info.xml; then
+    echo "version element not found in info.xml" >&2
+    exit 1
+  fi
+
+  if ! grep -q "<develStage>.*</develStage>" info.xml; then
+    echo "develStage element not found in info.xml" >&2
+    exit 1
+  fi
+
+  if ! grep -q -e "<releaseDate/>" -e "<releaseDate>.*</releaseDate>" info.xml; then
+    echo "releaseDate element not found in info.xml" >&2
+    exit 1
+  fi
+}
+
+updateInfoXml() {
+  local -r version=$1
+  local -r develStage=$2
+  local -r releaseDate=${3:-}
+
+  if [ -z "$releaseDate" ]; then
+    local -r releaseDateXml="<releaseDate/>"
+  else
+    local -r releaseDateXml="<releaseDate>$releaseDate</releaseDate>"
+  fi
+
+  sed -i -e "s#<version>.*</version>#<version>$version</version>#g" \
+    -e "s#<develStage>.*</develStage>#<develStage>$develStage</develStage>#g" \
+    -e "s#<releaseDate>.*</releaseDate>#$releaseDateXml#g" \
+    -e "s#<releaseDate/>#$releaseDateXml#g" \
+    info.xml
+}
+
+hasComposerRequires() {
+  if [ ! -f composer.json ]; then
+    return 1
+  fi
+
+  # All requires that are not "php" or "ext-*".
+  requires=$("$JQ" -r '.require|keys|.[]' composer.json 2>/dev/null | sed -e '/^php$/d' -e '/ext-.*/d')
+  [ "$requires" != "" ]
+}
+
+isVersionLesser() {
+  "$PHP" -r "if (version_compare('$1', '$2', '>=')) exit(1);"
+}
+
+getMinPhpVersion() {
+  local phpVersion=""
+  local -r phpConstraint=$("$JQ" --raw-output --monochrome-output .require.php composer.json)
+  if [ "$phpConstraint" = "null" ]; then
+    echo "PHP version constraint not found in composer.json. Please consider adding it" >&2
+    echo -n "Minimal supported PHP version: " >&2
+    read -r phpVersion
+  else
+    local -r oldIfs=$IFS
+    IFS=' |'
+    local constraint
+    for constraint in $phpConstraint; do
+      if [[ "$constraint" =~ ^(\^|~|>=)([0-9]+(\.[0-9]+(\.[0-9]+)?)?)$ ]]; then
+        if [ -z "$phpVersion" ] || isVersionLesser "${BASH_REMATCH[2]}" "$phpVersion"; then
+          phpVersion=${BASH_REMATCH[2]}
+        fi
+      fi
+    done
+    IFS=$oldIfs
+
+    if [ -n "$phpVersion" ]; then
+      echo -n "Minimal supported PHP version [$phpVersion]: " >&2
+      read -r input
+      if [ "$input" != "" ]; then
+        phpVersion=$input
+      fi
+    else
+      echo "Minimal supported PHP version could not be detected from composer version constraint. (Supported operators: ^, ~, >=, |)" >&2
+      echo -n "Minimal supported PHP version: " >&2
+      read -r phpVersion
+    fi
+  fi
+
+  echo "$phpVersion"
+}
+
+validateMinPhpVersion() {
+  if ! [[ "$1" =~ ^[0-9]+(\.[0-9]+(\.[0-9]+)?)?$ ]]; then
+    echo "$1 is not a supported minimal PHP version" >&2
+    exit 1
+  fi
+}
+
+updatePot() {
+  local -r potFiles=(l10n/*.pot)
+  if [ ${#potFiles[@]} -ge 1 ] && [ -e "${potFiles[0]}" ] && [ -x tools/update-pot.sh ]; then
+    echo "Update .pot file"
+    tools/update-pot.sh
+    if ! git diff --no-patch --exit-code "${potFiles[*]}"; then
+      echo ".pot file has changed. Please update the translation and push changes to the repository." >&2
+      exit 1
+    fi
+  fi
+}
+
+main() {
+  DRY_RUN=0
+  local noComposer=0
+  local noPotUpdate=0
+
+  while [ $# -gt 0 ]; do
+    case $1 in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+
+      --dry-run)
+        DRY_RUN=1
+        shift
+        ;;
+
+      --no-composer)
+        noComposer=1
+        shift
+        ;;
+
+      --no-pot-update)
+        noPotUpdate=1
+        shift
+        ;;
+
+      *)
+        break
+        ;;
+    esac
+  done
+
+  if [ $# -gt 3 ]; then
+    usage >&2
+    exit 1
+  fi
+
+  validateInfoXml
+
+  local version
+  local nextVersion
+  local develStage
+
+  if [ $# -ge 1 ]; then
+    version=$1
+  else
+    version=$(detectVersion)
+    echo -n "Version [$version]: "
+    read -r input
+    if [ -n "$input" ]; then
+      version=$input
+    fi
+  fi
+  validateVersion "$version"
+
+  if [ $# -ge 2 ]; then
+    develStage=$2
+  else
+    develStage=$(detectDevelStage "$version")
+    echo -n "Development stage [$develStage]: "
+    read -r input
+    if [ -n "$input" ]; then
+      develStage=$input
+    fi
+  fi
+  validateDevelopmentStage "$develStage"
+
+  if [ $# -ge 3 ]; then
+    nextVersion=$3
+  else
+    nextVersion=$(detectNextVersion "$version")
+    echo -n "Next version [$nextVersion]: "
+    read -r input
+    if [ -n "$input" ]; then
+      nextVersion=$input
+    fi
+  fi
+  validateNextVersion "$nextVersion"
+
+  if [ $noComposer -eq 0 ] && ! hasComposerRequires; then
+    noComposer=1
+  fi
+
+  if [ $noComposer -eq 0 ]; then
+    local -r minPhpVersion=$(getMinPhpVersion)
+    validateMinPhpVersion "$minPhpVersion"
+  fi
+
+  if [ $noPotUpdate -eq 0 ]; then
+    updatePot
+  fi
+
+  local -r releaseDate=$(date +%Y-%m-%d)
+  run updateInfoXml "$version" "$develStage" "$releaseDate"
+  run git add info.xml
+
+  if [ $noComposer -eq 0 ]; then
+    local -r previousPlatformPhp=$(composer config platform.php 2>/dev/null ||:)
+    run composer config platform.php "$minPhpVersion"
+    run composer update --no-dev --optimize-autoloader
+    if [ -n "$previousPlatformPhp" ]; then
+      run composer config platform.php "$previousPlatformPhp"
+    else
+      run composer config --unset platform.php
+    fi
+    run git add -f composer.lock vendor
+  fi
+
+  run git commit -m "Set version to $version"
+  run git tag "$version"
+
+  run updateInfoXml "$nextVersion" "dev"
+  run git add info.xml
+
+  if [ $noComposer -eq 0 ]; then
+    run git rm -r composer.lock vendor
+  fi
+
+  if [ -f composer.json ]; then
+    local -r branch=$(git branch --show-current)
+    if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+      [[ "$nextVersion" =~ ^([0-9]+\.[0-9]+)\.[0-9]+ ]]
+      local -r alias=${BASH_REMATCH[1]}.x-dev
+      run composer config "extra.branch-alias.dev-$branch" "$alias"
+      run git add composer.json
+    fi
+  fi
+
+  run git commit -m "Set version to $nextVersion"
+
+  echo ""
+  echo "Push changes with: git push && git push --tags"
+}
+
+main "$@"

--- a/tools/git/hooks-wrapper.sh
+++ b/tools/git/hooks-wrapper.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Inspired by https://github.com/sjungwirth/githooks/blob/949d55e84e92dfd84e9a73a8b7624bb2e4dbc872/bin/git/hooks-wrapper
+
+# This script needs to be symlinked to .git/hooks/<hookname>.
+
+set -e
+
+HOOKNAME=$(basename "$0")
+NATIVE_HOOKS_DIR=$(dirname "$0")
+CUSTOM_HOOKS_DIR=$(dirname "$(realpath "$0")")/hooks
+
+# Runs all executables in $CUSTOM_HOOKS_DIR/hooks/$HOOKNAME.d and
+# $NATIVE_HOOKS_DIR/$HOOKNAME.local if existent.
+
+exitcode=
+for hook in "$CUSTOM_HOOKS_DIR/$HOOKNAME.d/"*; do
+  if [ -x "$hook" ]; then
+    "$hook" "$@" || exitcode=${exitcode:-$?}
+  fi
+done
+
+if [ -x "$NATIVE_HOOKS_DIR/$HOOKNAME.local" ]; then
+  "$NATIVE_HOOKS_DIR/$HOOKNAME.local" "$@" || exitcode=${exitcode:-$?}
+fi
+
+# shellcheck disable=SC2086
+exit $exitcode

--- a/tools/git/hooks/pre-commit.d/remember-update-pot.sh
+++ b/tools/git/hooks/pre-commit.d/remember-update-pot.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Please remember to update the .pot file (tools/update-pot.sh) and the translation."
+

--- a/tools/git/hooks/pre-merge-commit.d/run-pre-commit-hook.sh
+++ b/tools/git/hooks/pre-merge-commit.d/run-pre-commit-hook.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. git-sh-setup
+if [ -x "$GIT_DIR/hooks/pre-commit" ]; then
+  exec "$GIT_DIR/hooks/pre-commit"
+fi

--- a/tools/git/init-hooks.sh
+++ b/tools/git/init-hooks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Inspired by https://github.com/sjungwirth/githooks/blob/949d55e84e92dfd84e9a73a8b7624bb2e4dbc872/bin/git/init-hooks
+
+set -e
+
+SCRIPT_DIR=$(dirname "$0")
+NATIVE_HOOKS_DIR=$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)/.git/hooks
+CUSTOM_HOOKS_DIR=$SCRIPT_DIR/hooks
+HOOKS_WRAPPER=$(realpath -s --relative-to="$NATIVE_HOOKS_DIR" "$SCRIPT_DIR")/hooks-wrapper.sh
+
+cd "$CUSTOM_HOOKS_DIR"
+HOOK_DIRS=(*.d)
+
+for hook_dir in "${HOOK_DIRS[@]}"; do
+  hookname=${hook_dir:0:-2}
+  if [ ! -L "$NATIVE_HOOKS_DIR/$hookname" ]; then
+    if [ -f "$NATIVE_HOOKS_DIR/$hookname" ]; then
+      mv "$NATIVE_HOOKS_DIR/$hookname" "$NATIVE_HOOKS_DIR/$hookname.local"
+    fi
+    ln -s "$HOOKS_WRAPPER" "$NATIVE_HOOKS_DIR/$hookname"
+  fi
+done

--- a/tools/phpstan/composer.json
+++ b/tools/phpstan/composer.json
@@ -1,13 +1,14 @@
 {
     "require": {
-        "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan": "^1.12",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.1",
-        "phpstan/phpstan-strict-rules": "^1.2",
-        "phpstan/phpstan-webmozart-assert": "^1.2",
-        "thecodingmachine/phpstan-strict-rules": "^1.0",
-        "voku/phpstan-rules": "^3.0"
+        "kcs/phpstan-strict-rules": "^2",
+        "phpstan/extension-installer": "^1.4",
+        "phpstan/phpstan": "^2",
+        "phpstan/phpstan-beberlei-assert": "^2",
+        "phpstan/phpstan-deprecation-rules": "^2",
+        "phpstan/phpstan-phpunit": "^2",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpstan/phpstan-webmozart-assert": "^2",
+        "voku/phpstan-rules": "^3.6"
     },
     "config": {
         "allow-plugins": {

--- a/tools/update-pot.sh
+++ b/tools/update-pot.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly SCRIPT_PATH="$0"
+SCRIPT_NAME=$(basename "$SCRIPT_PATH")
+readonly SCRIPT_NAME
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
+readonly SCRIPT_DIR
+
+usage() {
+  cat <<EOD
+Usage: $SCRIPT_NAME [-h|--help]
+  -h, --help
+            Print this help.
+
+Extracts translatable strings using civistrings and updates the .pot file.
+EOD
+}
+
+if [ $# -eq 1 ]; then
+  usage
+  if [ $1 = -h ] || [ $1 = --help ]; then
+    exit
+  fi
+  exit 1
+elif [ $# -gt 1 ]; then
+  usage
+  exit 1
+fi
+
+cd "$SCRIPT_DIR/.."
+
+[ -d l10n ] || mkdir l10n
+civistrings -o "l10n/remotetools.pot" - < <(git ls-files)

--- a/update_pot.sh
+++ b/update_pot.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-# quick and dirty script to update the .pot file
-l10n_tools="../civi_l10n_tools"
-${l10n_tools}/bin/create-pot-files-extensions.sh de.systopia.remotetools ./ l10n


### PR DESCRIPTION
This also makes symfony/html-sanitizer (depends on PHP >=8.1) a requirement, not just a suggestion.