### PR TITLE
Allow default values for a `FileField` in a `FieldListField`

### DIFF
--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormField.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormField.php
@@ -145,6 +145,13 @@ abstract class AbstractFormField extends AbstractFormInput {
     return $this;
   }
 
+  public function unsetDefaultValue(): static {
+    $this->hasDefaultValue = FALSE;
+    $this->defaultValue = NULL;
+
+    return $this;
+  }
+
   public function getDataTransformer(): FieldDataTransformerInterface {
     return IdentityFieldDataTransformer::getInstance();
   }

--- a/Civi/RemoteTools/Form/FormSpec/Field/FieldListField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/FieldListField.php
@@ -26,9 +26,6 @@ use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
  * This field type provides the possibility to enter multiple values of the same
  * type defined by the item field. The name of the item field has no influence.
  *
- * @todo Make it possible to use a default value when a FileField is used as
- * item.
- *
  * @extends AbstractFormField<list<scalar|array<int|string, mixed>>>
  *
  * @codeCoverageIgnore

--- a/Civi/RemoteTools/Form/FormSpec/Field/FileField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/FileField.php
@@ -22,6 +22,10 @@ namespace Civi\RemoteTools\Form\FormSpec\Field;
 use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
 
 /**
+ * Note: For default values with CiviCRM <6.1 the properties url and filename
+ * have to be set. It's not possible to use default values inside a
+ * FieldListField with CiviCRM <6.1.
+ *
  * @extends AbstractFormField<int>
  *
  * @codeCoverageIgnore
@@ -41,10 +45,16 @@ class FileField extends AbstractFormField {
     return 'integer';
   }
 
+  /**
+   * @deprecated 1.1.0 Filename is determined via File entity.
+   */
   public function getFilename(): ?string {
     return $this->filename;
   }
 
+  /**
+   * @deprecated 1.1.0 Filename is determined via File entity.
+   */
   public function setFilename(?string $filename): static {
     $this->filename = $filename;
 
@@ -75,10 +85,16 @@ class FileField extends AbstractFormField {
     return $this;
   }
 
+  /**
+   * @deprecated 1.1.0 URL is determined automatically (requires CiviCRM >=6.1.0)
+   */
   public function getUrl(): ?string {
     return $this->url;
   }
 
+  /**
+   * @deprecated 1.1.0 URL is determined automatically (requires CiviCRM >=6.1.0)
+   */
   public function setUrl(?string $url): static {
     $this->url = $url;
 

--- a/Civi/RemoteTools/Helper/FilePersisterInterface.php
+++ b/Civi/RemoteTools/Helper/FilePersisterInterface.php
@@ -20,6 +20,9 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\Helper;
 
 /**
+ * @phpstan-type fileT array{filename: string, content: string}
+ *   The property 'content' contains the Base64 encoded file.
+ *
  * @apiService
  */
 interface FilePersisterInterface {
@@ -36,8 +39,7 @@ interface FilePersisterInterface {
   /**
    * Requires an open database transaction.
    *
-   * @phpstan-param array{filename: string, content: string} $file
-   *   The property 'content' contains the Base64 encoded file.
+   * @phpstan-param fileT $file
    *
    * @returns int ID of File entity.
    *

--- a/Civi/RemoteTools/Helper/FileUrlGenerator.php
+++ b/Civi/RemoteTools/Helper/FileUrlGenerator.php
@@ -18,22 +18,22 @@
 
 declare(strict_types = 1);
 
-namespace Civi\RemoteTools\JsonSchema\FormSpec;
+namespace Civi\RemoteTools\Helper;
 
-use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
-use Civi\RemoteTools\JsonSchema\JsonSchema;
+/**
+ * @codeCoverageIgnore
+ */
+final class FileUrlGenerator implements FileUrlGeneratorInterface {
 
-interface RootFieldJsonSchemaFactoryInterface {
+  public function generateUrl(int $fileId, ?int $lifetimeHours): string {
+    // @phpstan-ignore function.alreadyNarrowedType
+    if (!method_exists(\Civi::class, 'url')) {
+      throw new \BadMethodCallException('UrlGenerator can not be used with this version of CiviCRM');
+    }
 
-  public function createSchema(AbstractFormField $field): JsonSchema;
+    $hash = \CRM_Core_BAO_File::generateFileHash(NULL, $fileId, \CRM_Utils_Time::time(), $lifetimeHours);
 
-  /**
-   * @param list<mixed> $defaultValues
-   *
-   * @return list<mixed>
-   */
-  public function convertDefaultValuesInList(AbstractFormField $field, array $defaultValues): array;
-
-  public function supportsField(AbstractFormField $field): bool;
+    return \Civi::url("frontend://civicrm/file?reset=1&id=$fileId&fcs=$hash", 'a')->__toString();
+  }
 
 }

--- a/Civi/RemoteTools/Helper/FileUrlGeneratorInterface.php
+++ b/Civi/RemoteTools/Helper/FileUrlGeneratorInterface.php
@@ -15,25 +15,20 @@
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 declare(strict_types = 1);
 
-namespace Civi\RemoteTools\JsonSchema\FormSpec;
+namespace Civi\RemoteTools\Helper;
 
-use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
-use Civi\RemoteTools\JsonSchema\JsonSchema;
-
-interface RootFieldJsonSchemaFactoryInterface {
-
-  public function createSchema(AbstractFormField $field): JsonSchema;
+interface FileUrlGeneratorInterface {
 
   /**
-   * @param list<mixed> $defaultValues
+   * Requires CiviCRM >= 6.1.0.
    *
-   * @return list<mixed>
+   * @param int $fileId
+   * @param int|null $lifetimeHours
+   *   The number of hours the link shall be valid. If NULL, the checksum
+   *   timeout configured in CiviCRM will be used.
    */
-  public function convertDefaultValuesInList(AbstractFormField $field, array $defaultValues): array;
-
-  public function supportsField(AbstractFormField $field): bool;
+  public function generateUrl(int $fileId, ?int $lifetimeHours): string;
 
 }

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/AbstractFieldJsonSchemaFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/AbstractFieldJsonSchemaFactory.php
@@ -34,6 +34,14 @@ abstract class AbstractFieldJsonSchemaFactory implements FieldJsonSchemaFactoryI
     return $this->doCreateSchema($field, $factory);
   }
 
+  public function convertDefaultValuesInList(
+    AbstractFormField $field,
+    array $defaultValues,
+    RootFieldJsonSchemaFactoryInterface $factory
+  ): array {
+    return $defaultValues;
+  }
+
   abstract protected function doCreateSchema(
     AbstractFormField $field,
     RootFieldJsonSchemaFactoryInterface $factory

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/BooleanFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/BooleanFieldFactory.php
@@ -35,10 +35,12 @@ final class BooleanFieldFactory extends AbstractFieldJsonSchemaFactory {
     Assert::nullOrBoolean($field->getDefaultValue());
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
 
     return new JsonSchemaBoolean($keywords, $field->isNullable());

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateFieldFactory.php
@@ -35,10 +35,12 @@ final class DateFieldFactory extends AbstractFieldJsonSchemaFactory {
     Assert::nullOrString($field->getDefaultValue());
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
 
     return new JsonSchemaString($keywords, $field->isNullable());

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateTimeFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/DateTimeFieldFactory.php
@@ -35,10 +35,12 @@ final class DateTimeFieldFactory extends AbstractFieldJsonSchemaFactory {
     Assert::nullOrString($field->getDefaultValue());
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
 
     return new JsonSchemaString($keywords, $field->isNullable());

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/IntegerFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/IntegerFieldFactory.php
@@ -36,10 +36,12 @@ final class IntegerFieldFactory extends AbstractFieldJsonSchemaFactory {
     Assert::nullOrInteger($field->getDefaultValue());
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
     if ($field instanceof AbstractNumberField) {
       if (NULL !== $field->getMaximum()) {

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/MultiOptionFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/MultiOptionFieldFactory.php
@@ -48,10 +48,12 @@ final class MultiOptionFieldFactory extends AbstractFieldJsonSchemaFactory {
     Assert::nullOrIsArray($field->getDefaultValue());
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
 
     Assert::notEmpty($field->getOptions(), sprintf('Options must not be empty (field: %s)', $field->getName()));

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/NumberFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/NumberFieldFactory.php
@@ -41,10 +41,12 @@ final class NumberFieldFactory extends AbstractFieldJsonSchemaFactory {
       || NULL === $field->getDefaultValue());
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
     if ($field instanceof AbstractNumberField) {
       if (NULL !== $field->getMaximum()) {

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/OptionFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/OptionFieldFactory.php
@@ -52,10 +52,12 @@ final class OptionFieldFactory extends AbstractFieldJsonSchemaFactory {
     }
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
 
     return new JsonSchema($keywords);

--- a/Civi/RemoteTools/JsonSchema/FormSpec/Factory/StringFieldFactory.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/Factory/StringFieldFactory.php
@@ -40,10 +40,12 @@ final class StringFieldFactory extends AbstractFieldJsonSchemaFactory {
     Assert::nullOrString($field->getDefaultValue());
     if ($field->hasDefaultValue()) {
       $keywords['default'] = $field->getDefaultValue();
+      if ($field->isReadOnly()) {
+        $keywords['const'] = $keywords['default'];
+      }
     }
     if ($field->isReadOnly()) {
       $keywords['readOnly'] = TRUE;
-      $keywords['const'] = $field->getDefaultValue();
     }
     if ($field instanceof AbstractTextField) {
       if (NULL !== $field->getMaxLength()) {

--- a/Civi/RemoteTools/JsonSchema/FormSpec/FieldJsonSchemaFactoryInterface.php
+++ b/Civi/RemoteTools/JsonSchema/FormSpec/FieldJsonSchemaFactoryInterface.php
@@ -30,6 +30,17 @@ interface FieldJsonSchemaFactoryInterface {
 
   public function createSchema(AbstractFormField $field, RootFieldJsonSchemaFactoryInterface $factory): JsonSchema;
 
+  /**
+   * @param list<mixed> $defaultValues
+   *
+   * @return list<mixed>
+   */
+  public function convertDefaultValuesInList(
+    AbstractFormField $field,
+    array $defaultValues,
+    RootFieldJsonSchemaFactoryInterface $factory
+  ): array;
+
   public function supportsField(AbstractFormField $field): bool;
 
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -27,6 +27,7 @@
         <!-- Conflicts with PHPStan type hints -->
         <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
         <exclude name="Drupal.Commenting.FunctionComment.ParamTypeSpaces"/>
+        <exclude name="Drupal.Commenting.FunctionComment.ReturnTypeSpaces"/>
 
         <!-- Don't enforce phpdoc type hint because it (might) only duplicate a PHP type hint -->
         <exclude name="Drupal.Commenting.VariableComment.MissingVar"/>

--- a/services/remote-tools.php
+++ b/services/remote-tools.php
@@ -44,6 +44,8 @@ use Civi\RemoteTools\EntityProfile\Helper\ProfileEntityLoaderInterface;
 use Civi\RemoteTools\EventSubscriber\RemoteRequestInitSubscriber;
 use Civi\RemoteTools\Helper\FilePersister;
 use Civi\RemoteTools\Helper\FilePersisterInterface;
+use Civi\RemoteTools\Helper\FileUrlGenerator;
+use Civi\RemoteTools\Helper\FileUrlGeneratorInterface;
 use Civi\RemoteTools\Helper\SelectFactory;
 use Civi\RemoteTools\Helper\SelectFactoryInterface;
 use Civi\RemoteTools\Helper\WhereFactory;
@@ -81,6 +83,7 @@ $container->autowire(RequestContextInterface::class, RequestContext::class)
 
 $container->autowire(TransactionFactory::class);
 $container->autowire(FilePersisterInterface::class, FilePersister::class);
+$container->autowire(FileUrlGeneratorInterface::class, FileUrlGenerator::class);
 
 $container->autowire(ActionHandlerProviderInterface::class, ActionHandlerProviderCollection::class)
   ->addArgument(new TaggedIteratorArgument(ActionHandlerProviderInterface::SERVICE_TAG));

--- a/tests/phpunit/Civi/RemoteTools/JsonSchema/FormSpec/Factory/FieldListFieldFactoryTest.php
+++ b/tests/phpunit/Civi/RemoteTools/JsonSchema/FormSpec/Factory/FieldListFieldFactoryTest.php
@@ -79,10 +79,13 @@ final class FieldListFieldFactoryTest extends TestCase {
       })
       ->willReturn($itemSchema);
 
+    $rootFactory->expects(static::once())->method('convertDefaultValuesInList')
+      ->with($itemField, [123])
+      ->willReturn([123]);
+
     static::assertEquals(
       new JsonSchemaArray($itemSchema, [
         'default' => JsonSchema::convertToJsonSchemaArray([123]),
-        'const' => JsonSchema::convertToJsonSchemaArray([123]),
         'readOnly' => TRUE,
         'minItems' => 1,
         'maxItems' => 3,


### PR DESCRIPTION
The default value of a `FileField` can be a `File` ID. However, when the corresponding schema is generated the ID has to be transformed to be useful in the frontend. This PR make it possible to convert default values of a `FieldListField`.

systopia-reference: 29899