### PR TITLE
Add support for attached files

### DIFF
--- a/Civi/RemoteTools/Form/FormSpec/AbstractFormField.php
+++ b/Civi/RemoteTools/Form/FormSpec/AbstractFormField.php
@@ -28,6 +28,8 @@ namespace Civi\RemoteTools\Form\FormSpec;
  */
 abstract class AbstractFormField extends AbstractFormInput {
 
+  private FieldDataTransformerChain $dataTransformer;
+
   private bool $hidden = FALSE;
 
   private bool $required = FALSE;
@@ -42,6 +44,11 @@ abstract class AbstractFormField extends AbstractFormInput {
    * @phpstan-var T|null
    */
   private mixed $defaultValue = NULL;
+
+  public function __construct(string $name, string $label) {
+    parent::__construct($name, $label);
+    $this->dataTransformer = new FieldDataTransformerChain([]);
+  }
 
   public function getType(): string {
     return 'field';
@@ -152,8 +159,27 @@ abstract class AbstractFormField extends AbstractFormInput {
     return $this;
   }
 
+  public function appendDataTransformer(FieldDataTransformerInterface $transformer): static {
+    $this->dataTransformer->appendTransformer($transformer);
+
+    return $this;
+  }
+
   public function getDataTransformer(): FieldDataTransformerInterface {
-    return IdentityFieldDataTransformer::getInstance();
+    return $this->dataTransformer;
+  }
+
+  public function prependDataTransformer(FieldDataTransformerInterface $transformer): static {
+    $this->dataTransformer->prependTransformer($transformer);
+
+    return $this;
+  }
+
+  public function setDataTransformer(FieldDataTransformerInterface $transformer): static {
+    $this->dataTransformer = $transformer instanceof FieldDataTransformerChain ? $transformer :
+      new FieldDataTransformerChain([$transformer]);
+
+    return $this;
   }
 
   public function getValidator(): FieldValidatorInterface {

--- a/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldCollectionFieldDataTransformer.php
+++ b/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldCollectionFieldDataTransformer.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Form\FormSpec\DataTransformer;
+
+use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
+use Civi\RemoteTools\Form\FormSpec\Field\FieldCollectionField;
+use Civi\RemoteTools\Form\FormSpec\FieldDataTransformerInterface;
+
+final class FieldCollectionFieldDataTransformer implements FieldDataTransformerInterface {
+
+  private static self $instance;
+
+  public static function getInstance(): FieldCollectionFieldDataTransformer {
+    return self::$instance ??= new self();
+  }
+
+  public function toEntityValue(mixed $data, AbstractFormField $field, ?array $defaultValuesInList = NULL): mixed {
+    assert($field instanceof FieldCollectionField);
+    if (is_array($data)) {
+      foreach ($field->getFields() as $subField) {
+        if (array_key_exists($subField->getName(), $data)) {
+          $subFieldDefaultValuesInList = NULL === $defaultValuesInList ? NULL
+            : array_column($defaultValuesInList, $subField->getName());
+          $data[$subField->getName()] = $subField->getDataTransformer()
+            ->toEntityValue($data[$subField->getName()], $subField, $subFieldDefaultValuesInList);
+        }
+      }
+    }
+
+    return $data;
+  }
+
+}

--- a/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldListFieldDataTransformer.php
+++ b/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldListFieldDataTransformer.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Form\FormSpec\DataTransformer;
+
+use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
+use Civi\RemoteTools\Form\FormSpec\Field\FieldListField;
+use Civi\RemoteTools\Form\FormSpec\FieldDataTransformerInterface;
+use Webmozart\Assert\Assert;
+
+final class FieldListFieldDataTransformer implements FieldDataTransformerInterface {
+
+  private static self $instance;
+
+  public static function getInstance(): FieldListFieldDataTransformer {
+    return self::$instance ??= new self();
+  }
+
+  public function toEntityValue(mixed $data, AbstractFormField $field, ?array $defaultValuesInList = NULL): mixed {
+    assert($field instanceof FieldListField);
+    if (is_array($data)) {
+      $itemField = $field->getItemField();
+      $itemFieldTransformer = $itemField->getDataTransformer();
+      if (NULL === $defaultValuesInList) {
+        $defaultValuesInList = $field->getDefaultValue();
+      }
+      else {
+        Assert::allNullOrIsArray($defaultValuesInList);
+        /** @var list<mixed> $defaultValuesInList */
+        $defaultValuesInList = array_merge(...array_filter($defaultValuesInList, fn ($value) => $value !== NULL));
+      }
+
+      foreach ($data as &$value) {
+        $value = $itemFieldTransformer->toEntityValue($value, $itemField, $defaultValuesInList);
+      }
+    }
+
+    return $data;
+  }
+
+}

--- a/Civi/RemoteTools/Form/FormSpec/DataTransformer/HtmlDataTransformer.php
+++ b/Civi/RemoteTools/Form/FormSpec/DataTransformer/HtmlDataTransformer.php
@@ -32,7 +32,7 @@ final class HtmlDataTransformer implements FieldDataTransformerInterface {
   /**
    * @inheritDoc
    */
-  public function toEntityValue(mixed $data, AbstractFormField $field): mixed {
+  public function toEntityValue(mixed $data, AbstractFormField $field, ?array $defaultValuesInList = NULL): mixed {
     if (!is_string($data)) {
       return NULL;
     }

--- a/Civi/RemoteTools/Form/FormSpec/Field/AttachmentsField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/AttachmentsField.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Form\FormSpec\Field;
+
+use CRM_Remotetools_ExtensionUtil as E;
+
+/**
+ * Can be used for entities that allow attached files like Activity.
+ *
+ * This field is supposed to be used in combination with AttachmentsLoader and
+ * AttachmentsPersister.
+ *
+ * @see \Civi\RemoteTools\Helper\AttachmentsLoaderInterface
+ * @see \Civi\RemoteTools\Helper\AttachmentsPersisterInterface
+ */
+final class AttachmentsField extends FieldListField {
+
+  private TextField $descriptionField;
+
+  private FileField $fileField;
+
+  public function __construct(string $name, string $label) {
+    $this->descriptionField = new TextField('description', E::ts('Description'));
+    $this->fileField = (new FileField('file', E::ts('File')))->setRequired(TRUE);
+
+    parent::__construct($name, $label, new FieldCollectionField('', '', [
+      $this->fileField,
+      $this->descriptionField,
+    ]));
+  }
+
+  /**
+   * @phpstan-return non-negative-int
+   *   If maxItems is not set the value of "max_attachments" in the CiviCRM
+   *   settings is returned.
+   */
+  public function getMaxItems(): int {
+    // @phpstan-ignore cast.int, return.type
+    return parent::getMaxItems() ?? (int) \Civi::settings()->get('max_attachments');
+  }
+
+  public function setDescriptionFieldLabel(string $label): static {
+    $this->descriptionField->setLabel($label);
+
+    return $this;
+  }
+
+  public function setDescriptionFieldRequired(bool $required): static {
+    $this->descriptionField->setRequired($required);
+
+    return $this;
+  }
+
+  public function setFileFieldLabel(string $label): static {
+    $this->fileField->setLabel($label);
+
+    return $this;
+  }
+
+}

--- a/Civi/RemoteTools/Form/FormSpec/Field/FieldCollectionField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/FieldCollectionField.php
@@ -21,6 +21,7 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\Form\FormSpec\Field;
 
 use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
+use Civi\RemoteTools\Form\FormSpec\DataTransformer\FieldCollectionFieldDataTransformer;
 
 /**
  * This field combines the input of multiple fields to a single property.
@@ -31,7 +32,7 @@ use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
  *
  * @api
  */
-final class FieldCollectionField extends AbstractFormField {
+class FieldCollectionField extends AbstractFormField {
 
   /**
    * @var list<\Civi\RemoteTools\Form\FormSpec\AbstractFormField>
@@ -44,6 +45,7 @@ final class FieldCollectionField extends AbstractFormField {
   public function __construct(string $name, string $label, array $fields = []) {
     parent::__construct($name, $label);
     $this->fields = $fields;
+    $this->appendDataTransformer(FieldCollectionFieldDataTransformer::getInstance());
   }
 
   public function getDataType(): string {

--- a/Civi/RemoteTools/Form/FormSpec/Field/FieldListField.php
+++ b/Civi/RemoteTools/Form/FormSpec/Field/FieldListField.php
@@ -21,6 +21,7 @@ declare(strict_types = 1);
 namespace Civi\RemoteTools\Form\FormSpec\Field;
 
 use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
+use Civi\RemoteTools\Form\FormSpec\DataTransformer\FieldListFieldDataTransformer;
 
 /**
  * This field type provides the possibility to enter multiple values of the same
@@ -32,7 +33,7 @@ use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
  *
  * @api
  */
-final class FieldListField extends AbstractFormField {
+class FieldListField extends AbstractFormField {
 
   public const LAYOUT_VERTICAL = 'VerticalLayout';
 
@@ -61,6 +62,7 @@ final class FieldListField extends AbstractFormField {
   public function __construct(string $name, string $label, AbstractFormField $itemField) {
     parent::__construct($name, $label);
     $this->itemField = $itemField;
+    $this->appendDataTransformer(FieldListFieldDataTransformer::getInstance());
   }
 
   public function getDataType(): string {

--- a/Civi/RemoteTools/Form/FormSpec/FieldDataTransformerChain.php
+++ b/Civi/RemoteTools/Form/FormSpec/FieldDataTransformerChain.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Form\FormSpec;
+
+final class FieldDataTransformerChain implements FieldDataTransformerInterface {
+
+  /**
+   * @var iterable<FieldDataTransformerInterface>
+   */
+  private iterable $transformers;
+
+  /**
+   * @param iterable<FieldDataTransformerInterface> $transformers
+   */
+  public function __construct(iterable $transformers) {
+    $this->transformers = $transformers;
+  }
+
+  public function appendTransformer(FieldDataTransformerInterface $transformer): void {
+    $this->transformers = [...$this->transformers, $transformer];
+  }
+
+  public function prependTransformer(FieldDataTransformerInterface $transformer): void {
+    $this->transformers = [$transformer, ...$this->transformers];
+  }
+
+  public function toEntityValue(mixed $data, AbstractFormField $field, ?array $defaultValuesInList = NULL): mixed {
+    foreach ($this->transformers as $transformer) {
+      $data = $transformer->toEntityValue($data, $field, $defaultValuesInList);
+    }
+
+    return $data;
+  }
+
+}

--- a/Civi/RemoteTools/Form/FormSpec/FieldDataTransformerInterface.php
+++ b/Civi/RemoteTools/Form/FormSpec/FieldDataTransformerInterface.php
@@ -12,7 +12,13 @@ interface FieldDataTransformerInterface {
 
   /**
    * @phpstan-param T $field
+   * phpcs:disable Drupal.Commenting.FunctionComment.ParamNameNoMatch, Squiz.PHP.CommentedOutCode.Found
+   * @param list<mixed>|null $defaultValuesInList
+   *   The default values for this field when used in a FieldListField. This
+   *   parameter will be required in implementations from version 2.0.0 on.
+   *
+   * @phpstan-ignore parameter.notFound
    */
-  public function toEntityValue(mixed $data, AbstractFormField $field): mixed;
+  public function toEntityValue(mixed $data, AbstractFormField $field/*, ?array $defaultValuesInList = NULL*/): mixed;
 
 }

--- a/Civi/RemoteTools/Form/FormSpec/IdentityFieldDataTransformer.php
+++ b/Civi/RemoteTools/Form/FormSpec/IdentityFieldDataTransformer.php
@@ -14,7 +14,7 @@ final class IdentityFieldDataTransformer implements FieldDataTransformerInterfac
   /**
    * @inheritDoc
    */
-  public function toEntityValue(mixed $data, AbstractFormField $field): mixed {
+  public function toEntityValue(mixed $data, AbstractFormField $field, ?array $defaultValuesInList = NULL): mixed {
     return $data;
   }
 

--- a/Civi/RemoteTools/Helper/AttachmentsLoader.php
+++ b/Civi/RemoteTools/Helper/AttachmentsLoader.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Helper;
+
+use Civi\RemoteTools\Api4\Api4Interface;
+
+final class AttachmentsLoader implements AttachmentsLoaderInterface {
+
+  private Api4Interface $api4;
+
+  private DaoEntityInfoProvider $daoEntityInfoProvider;
+
+  public function __construct(
+    Api4Interface $api4,
+    DaoEntityInfoProvider $daoEntityInfoProvider
+  ) {
+    $this->api4 = $api4;
+    $this->daoEntityInfoProvider = $daoEntityInfoProvider;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function getAttachments(string $entityName, int $entityId): array {
+    $files = $this->api4->execute('File', 'get', [
+      'select' => ['id', 'file_name', 'description'],
+      'join' => [
+        [
+          'EntityFile AS entity_file',
+          'INNER',
+          ['entity_file.file_id', '=', 'id'],
+          ['entity_file.entity_table', '=', '"' . $this->daoEntityInfoProvider->getTableName($entityName) . '"'],
+          ['entity_file.entity_id', '=', $entityId],
+        ],
+      ],
+    ])->getArrayCopy();
+
+    $attachments = [];
+    /** @phpstan-var array{id: int, description: string|null} $file */
+    foreach ($files as $file) {
+      $attachments[] = ['file' => $file['id'], 'description' => $file['description']];
+    }
+
+    return $attachments;
+  }
+
+}

--- a/Civi/RemoteTools/Helper/AttachmentsLoaderInterface.php
+++ b/Civi/RemoteTools/Helper/AttachmentsLoaderInterface.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Helper;
+
+/**
+ * @see \Civi\RemoteTools\Form\FormSpec\Field\AttachmentsField
+ * @see \Civi\RemoteTools\Helper\AttachmentsPeristerInterface
+ *
+ * @apiService
+ */
+interface AttachmentsLoaderInterface {
+
+  /**
+   * @return list<array{file: int, description: string|null}>
+   *   Can be used as default value in AttachmentsField.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function getAttachments(string $entityName, int $entityId): array;
+
+}

--- a/Civi/RemoteTools/Helper/AttachmentsPersister.php
+++ b/Civi/RemoteTools/Helper/AttachmentsPersister.php
@@ -1,0 +1,88 @@
+<?php
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Helper;
+
+use Civi\RemoteTools\Api4\Api4Interface;
+use Civi\RemoteTools\Api4\Query\Comparison;
+use Civi\RemoteTools\Api4\Query\CompositeCondition;
+
+final class AttachmentsPersister implements AttachmentsPersisterInterface {
+
+  private Api4Interface $api4;
+
+  private DaoEntityInfoProvider $daoEntityInfoProvider;
+
+  private FilePersisterInterface $filePersister;
+
+  public function __construct(
+    Api4Interface $api4,
+    DaoEntityInfoProvider $daoEntityInfoProvider,
+    FilePersisterInterface $filePersister
+  ) {
+    $this->api4 = $api4;
+    $this->daoEntityInfoProvider = $daoEntityInfoProvider;
+    $this->filePersister = $filePersister;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  public function persistAttachmentsFromForm(
+    string $entityName,
+    int $entityId,
+    array $attachments,
+    ?int $contactId
+  ): void {
+    /** @var list<int> $previousFileIds */
+    $previousFileIds = $this->api4->getEntities('EntityFile', CompositeCondition::fromFieldValuePairs([
+      'entity_table' => $this->daoEntityInfoProvider->getTableName($entityName),
+      'entity_id' => $entityId,
+    ]))->column('file_id');
+    $newFileIds = [];
+
+    foreach ($attachments as $attachment) {
+      if (is_int($attachment['file'])) {
+        $this->api4->updateEntity('File', $attachment['file'], ['description' => $attachment['description']]);
+        $newFileIds[] = $attachment['file'];
+      }
+      else {
+        $fileId = $this->filePersister->persistFileFromForm(
+          $attachment['file'],
+          $attachment['description'],
+          $contactId
+        );
+        $this->api4->createEntity('EntityFile', [
+          'entity_table' => $this->daoEntityInfoProvider->getTableName($entityName),
+          'entity_id' => $entityId,
+          'file_id' => $fileId,
+        ])->single();
+        $newFileIds[] = $fileId;
+      }
+    }
+
+    /** @var list<int> $deletedFileIds */
+    $deletedFileIds = array_diff($previousFileIds, $newFileIds);
+    if ([] !== $deletedFileIds) {
+      $this->api4->deleteEntities('EntityFile', Comparison::new('file_id', 'IN', $deletedFileIds));
+      $this->api4->deleteEntities('File', Comparison::new('id', 'IN', $deletedFileIds));
+    }
+  }
+
+}

--- a/Civi/RemoteTools/Helper/AttachmentsPersisterInterface.php
+++ b/Civi/RemoteTools/Helper/AttachmentsPersisterInterface.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Helper;
+
+/**
+ * @phpstan-import-type fileT from FilePersisterInterface
+ * @phpstan-type attachmentT array{file: fileT|int, description: string|null}
+ *   "file" contains the new file or the ID of the previous, unchanged file.
+ *
+ * @see \Civi\RemoteTools\Form\FormSpec\Field\AttachmentsField
+ * @see \Civi\RemoteTools\Helper\AttachmentsLoaderInterface
+ *
+ * @apiService
+ */
+interface AttachmentsPersisterInterface {
+
+  /**
+   * @phpstan-param list<attachmentT> $attachments
+   *   Submitted data from AttachmentsField.
+   *
+   * @throws \CRM_Core_Exception
+   */
+  public function persistAttachmentsFromForm(
+    string $entityName,
+    int $entityId,
+    array $attachments,
+    ?int $contactId
+  ): void;
+
+}

--- a/Civi/RemoteTools/Helper/DaoEntityInfoProvider.php
+++ b/Civi/RemoteTools/Helper/DaoEntityInfoProvider.php
@@ -1,0 +1,36 @@
+<?php
+/*
+ * Copyright (C) 2024 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Affero General Public License as published by
+ *  the Free Software Foundation in version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Helper;
+
+/**
+ * @codeCoverageIgnore
+ */
+class DaoEntityInfoProvider {
+
+  public function getTableName(string $entityName): string {
+    $tableName = \CRM_Core_DAO_AllCoreTables::getTableForEntityName($entityName);
+    if (!is_string($tableName)) {
+      throw new \InvalidArgumentException('Unknown entity "' . $entityName . '"');
+    }
+
+    return $tableName;
+  }
+
+}

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,9 @@
+# Upgrade notes for developers
+
+# 2.0.0
+
+(Not released, yet.)
+
+* The interface `\Civi\RemoteTools\Form\FormSpec\FieldDataTransformerInterface`
+will require `?array $defaultValuesInList = NULL` as third parameter. It should
+be added already now in implementations.

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/mime": ">=4.4",
         "systopia/expression-language-ext": "~0.1",
         "systopia/opis-json-schema-ext": "~0.4",
-        "webmozart/assert": "^1.5"
+        "webmozart/assert": "^1.11"
     },
     "scripts": {
         "composer-phpcs": [

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1119,12 +1119,6 @@ parameters:
 			path: Civi/RemoteToolsRequest.php
 
 		-
-			message: '#^Method Civi\\RemoteToolsRequest\:\:setSorting\(\) never assigns null to &\$request_data so it can be removed from the by\-ref type\.$#'
-			identifier: parameterByRef.unusedType
-			count: 1
-			path: Civi/RemoteToolsRequest.php
-
-		-
 			message: '#^Method Civi\\RemoteToolsRequest\:\:wasExecuted\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -51,6 +51,8 @@ parameters:
 			path: */Civi/RemoteTools/Api4/Action/Traits/*
 			identifier: trait.unused
 
+		- '#^Method Civi\\RemoteTools\\Form\\FormSpec\\FieldDataTransformerInterface<[^>]+>::toEntityValue\(\) invoked with 3 parameters, 2 required.$#'
+		- '#^Method .+::toEntityValue\(\) has parameter \$defaultValuesInList with no value type specified in iterable type array.$#'
 		- '#^Method Civi\\RemoteTools\\Api4\\Action\\[^\s]+Action::getHandlerResult\(\) has Civi\\RemoteTools\\Exception\\ActionHandlerNotFoundException in PHPDoc @throws tag but it.s not thrown.$#'
 		- '#^Method Civi\\RemoteTools\\Api4\\Api4::createAction\(\) should return Civi\\Api4\\Generic\\AbstractAction but returns array|Civi\Api4\Generic\AbstractAction.$#'
 

--- a/services/remote-tools.php
+++ b/services/remote-tools.php
@@ -44,6 +44,11 @@ use Civi\RemoteTools\EntityProfile\Helper\ProfileEntityLoaderInterface;
 use Civi\RemoteTools\EventSubscriber\RemoteRequestInitSubscriber;
 use Civi\RemoteTools\Form\FormSpec\FormFieldFactory;
 use Civi\RemoteTools\Form\FormSpec\FormFieldFactoryInterface;
+use Civi\RemoteTools\Helper\AttachmentsLoader;
+use Civi\RemoteTools\Helper\AttachmentsLoaderInterface;
+use Civi\RemoteTools\Helper\AttachmentsPersister;
+use Civi\RemoteTools\Helper\AttachmentsPersisterInterface;
+use Civi\RemoteTools\Helper\DaoEntityInfoProvider;
 use Civi\RemoteTools\Helper\FilePersister;
 use Civi\RemoteTools\Helper\FilePersisterInterface;
 use Civi\RemoteTools\Helper\FileUrlGenerator;
@@ -86,6 +91,9 @@ $container->autowire(RequestContextInterface::class, RequestContext::class)
 $container->autowire(TransactionFactory::class);
 $container->autowire(FilePersisterInterface::class, FilePersister::class);
 $container->autowire(FileUrlGeneratorInterface::class, FileUrlGenerator::class);
+$container->autowire(AttachmentsLoaderInterface::class, AttachmentsLoader::class);
+$container->autowire(AttachmentsPersisterInterface::class, AttachmentsPersister::class);
+$container->autowire(DaoEntityInfoProvider::class);
 
 $container->autowire(FormFieldFactoryInterface::class, FormFieldFactory::class);
 

--- a/tests/phpunit/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldCollectionFieldDataTransformerTest.php
+++ b/tests/phpunit/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldCollectionFieldDataTransformerTest.php
@@ -1,0 +1,91 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Form\FormSpec\DataTransformer;
+
+use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
+use Civi\RemoteTools\Form\FormSpec\Field\FieldCollectionField;
+use Civi\RemoteTools\Form\FormSpec\Field\TextField;
+use Civi\RemoteTools\Form\FormSpec\FieldDataTransformerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\RemoteTools\Form\FormSpec\DataTransformer\FieldCollectionFieldDataTransformer
+ */
+final class FieldCollectionFieldDataTransformerTest extends TestCase {
+
+  public function test(): void {
+    $textField = (new TextField('text', ''))->setDataTransformer(
+      new class implements FieldDataTransformerInterface {
+
+        public function toEntityValue(
+          mixed $data,
+          AbstractFormField $field,
+          ?array $defaultValuesInList = NULL
+        ): mixed {
+          FieldCollectionFieldDataTransformerTest::assertNull($defaultValuesInList);
+          /** @var string $data */
+          return $data . 'Test';
+        }
+
+      }
+    );
+
+    $field = new FieldCollectionField('collection', 'Collection', [$textField]);
+    static::assertSame(
+      ['text' => 'fooTest'],
+      $field->getDataTransformer()->toEntityValue(['text' => 'foo'], $field, NULL)
+    );
+
+    static::assertSame(['foo' => 'bar'], $field->getDataTransformer()->toEntityValue(['foo' => 'bar'], $field, NULL));
+    static::assertNull($field->getDataTransformer()->toEntityValue(NULL, $field, NULL));
+
+  }
+
+  public function testWithDefaultValuesInList(): void {
+    $textField = (new TextField('text', ''))->setDataTransformer(
+      new class implements FieldDataTransformerInterface {
+
+        public function toEntityValue(
+          mixed $data,
+          AbstractFormField $field,
+          ?array $defaultValuesInList = NULL
+        ): mixed {
+          FieldCollectionFieldDataTransformerTest::assertSame($defaultValuesInList, ['foo', 'bar']);
+          /** @var string $data */
+          return $data . 'Test';
+        }
+
+      }
+    );
+
+    $field = new FieldCollectionField('collection', 'Collection', [$textField]);
+    $defaultValuesInList = [
+      ['text' => 'foo'],
+      ['text' => 'bar'],
+    ];
+    static::assertSame(
+      ['text' => 'bazTest'],
+      $field->getDataTransformer()->toEntityValue(['text' => 'baz'], $field, $defaultValuesInList)
+    );
+
+  }
+
+}

--- a/tests/phpunit/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldListFieldDataTransformerTest.php
+++ b/tests/phpunit/Civi/RemoteTools/Form/FormSpec/DataTransformer/FieldListFieldDataTransformerTest.php
@@ -1,0 +1,113 @@
+<?php
+/*
+ * Copyright (C) 2025 SYSTOPIA GmbH
+ *
+ *  This program is free software: you can redistribute it and/or modify it under
+ *  the terms of the GNU Affero General Public License as published by the Free
+ *  Software Foundation, either version 3 of the License, or (at your option) any
+ *  later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Civi\RemoteTools\Form\FormSpec\DataTransformer;
+
+use Civi\RemoteTools\Form\FormSpec\AbstractFormField;
+use Civi\RemoteTools\Form\FormSpec\Field\FieldListField;
+use Civi\RemoteTools\Form\FormSpec\Field\TextField;
+use Civi\RemoteTools\Form\FormSpec\FieldDataTransformerInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Civi\RemoteTools\Form\FormSpec\DataTransformer\FieldListFieldDataTransformer
+ */
+final class FieldListFieldDataTransformerTest extends TestCase {
+
+  public function test(): void {
+    $itemField = (new TextField('', ''))->setDataTransformer(
+      new class implements FieldDataTransformerInterface {
+
+        public function toEntityValue(
+          mixed $data,
+          AbstractFormField $field,
+          ?array $defaultValuesInList = NULL
+        ): mixed {
+          FieldListFieldDataTransformerTest::assertNull($defaultValuesInList);
+          /** @var string $data */
+          return $data . 'Test';
+        }
+
+      }
+    );
+
+    $field = new FieldListField('list', 'List', $itemField);
+    static::assertSame(
+      ['fooTest', 'barTest'],
+      $field->getDataTransformer()->toEntityValue(['foo', 'bar'], $field, NULL)
+    );
+
+    static::assertNull($field->getDataTransformer()->toEntityValue(NULL, $field, NULL));
+
+  }
+
+  public function testWithDefaultValue(): void {
+    $itemField = (new TextField('', ''))->setDataTransformer(
+      new class implements FieldDataTransformerInterface {
+
+        public function toEntityValue(
+          mixed $data,
+          AbstractFormField $field,
+          ?array $defaultValuesInList = NULL
+        ): mixed {
+          FieldListFieldDataTransformerTest::assertSame(['foo', 'bar'], $defaultValuesInList);
+          /** @var string $data */
+          return $data . 'Test';
+        }
+
+      }
+    );
+
+    $field = (new FieldListField('list', 'List', $itemField))->setDefaultValue(['foo', 'bar']);
+    static::assertSame(
+      ['bazTest'],
+      $field->getDataTransformer()->toEntityValue(['baz'], $field, NULL)
+    );
+
+  }
+
+  public function testWithDefaultValuesInList(): void {
+    $itemField = (new TextField('', ''))->setDataTransformer(
+      new class implements FieldDataTransformerInterface {
+
+        public function toEntityValue(
+          mixed $data,
+          AbstractFormField $field,
+          ?array $defaultValuesInList = NULL
+        ): mixed {
+          // Values should be merged together.
+          FieldListFieldDataTransformerTest::assertSame($defaultValuesInList, ['foo', 'bar']);
+          /** @var string $data */
+          return $data . 'Test';
+        }
+
+      }
+    );
+
+    $field = new FieldListField('list', 'List', $itemField);
+    $defaultValuesInList = [['foo'], ['bar']];
+    static::assertSame(
+      ['fooTest', 'bazTest'],
+      $field->getDataTransformer()->toEntityValue(['foo', 'baz'], $field, $defaultValuesInList)
+    );
+
+  }
+
+}


### PR DESCRIPTION
The new `AttachmentField` is meant to be used for entities that allow attached files like `Activity`. The corresponding loader and persister services can be used to load the default value and to persist the submitted form data.

Now the data transformers of an item field in a `FieldListField` and the fields in a `FieldCollectionField` are called now. This should have been done before. However, it's now required.

In `\Civi\RemoteTools\EntityProfile\EntityProfileFileDecorator` a comment said:
> It's not possible to set a custom file field to NULL. (The previous value is unchanged.)

That's not true anymore for recent CiviCRM versions. Therefore, it is removed.

systopia-reference: 29899