### PR TITLE
Return entity ID on successful form submit

### DIFF
--- a/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandler.php
+++ b/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandler.php
@@ -351,10 +351,13 @@ abstract class AbstractProfileEntityActionsHandler implements RemoteEntityAction
     ?int $contactId
   ): array {
     $message = $this->profile->getSaveSuccessMessage($newValues, $oldValues, $formData, $contactId);
+    $result = ['message' => $message];
 
-    return [
-      'message' => $message,
-    ];
+    if (isset($newValues['id'])) {
+      $result['entityId'] = $newValues['id'];
+    }
+
+    return $result;
   }
 
   /**

--- a/tests/phpunit/Civi/Api4/RemoteEntityTest.php
+++ b/tests/phpunit/Civi/Api4/RemoteEntityTest.php
@@ -326,13 +326,17 @@ final class RemoteEntityTest extends AbstractRemoteToolsHeadlessTestCase {
       ->setArguments(['x' => 'y'])
       ->setData(['name' => 'bar', 'title' => 'Bar'])
       ->execute();
-    static::assertSame(['message' => 'Saved successfully'], $result->getArrayCopy());
+    static::assertEquals(['message', 'entityId'], array_keys($result->getArrayCopy()));
+    static::assertSame('Saved successfully', $result['message']);
+    static::assertIsInt($result['entityId']);
+    $entityId = $result['entityId'];
 
     $result = Group::get(FALSE)
       ->addWhere('name', '=', 'bar')
       ->addWhere('title', '=', 'Bar')
       ->execute();
     static::assertCount(1, $result);
+    static::assertSame($entityId, $result->single()['id']);
   }
 
   /**
@@ -506,7 +510,10 @@ final class RemoteEntityTest extends AbstractRemoteToolsHeadlessTestCase {
       ->setId($group['id'])
       ->setData(['name' => 'xy'])
       ->execute();
-    static::assertSame(['message' => 'Saved successfully'], $result->getArrayCopy());
+    static::assertSame(
+      ['message' => 'Saved successfully', 'entityId' => $group['id']],
+      $result->getArrayCopy()
+    );
 
     $result = Group::get(FALSE)
       ->addWhere('name', '=', 'xy')

--- a/tests/phpunit/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandlerTest.php
+++ b/tests/phpunit/Civi/RemoteTools/ActionHandler/AbstractProfileEntityActionsHandlerTest.php
@@ -319,7 +319,10 @@ final class AbstractProfileEntityActionsHandlerTest extends TestCase {
       ->with($createdValues, NULL, $formData, self::RESOLVED_CONTACT_ID)
       ->willReturn('Ok');
 
-    static::assertSame(['message' => 'Ok'], $this->handler->submitCreateForm($actionMock));
+    static::assertEquals(
+      ['message' => 'Ok', 'entityId' => 12],
+      $this->handler->submitCreateForm($actionMock)
+    );
   }
 
   public function testGetUpdateForm(): void {


### PR DESCRIPTION
In addition to the message the entity ID is returned. On update this might be superfluous, but on create the ID can be used for example to redirect to another URL.

Corresponds to https://github.com/systopia/civiremote/pull/61.

systopia-reference: 30384 